### PR TITLE
feat: implement SpinSession entity for audit tracking closes #51

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { Bet } from './bets/entities/bet.entity';
 import { PlayerCardMetadata } from './player-card-metadata/entities/player-card-metadata.entity';
 import { Prediction } from './predictions/entities/prediction.entity';
 import { Spin } from './spin/entities/spin.entity';
+import { SpinSession } from './spin/entities/spin-session.entity';
 import configuration from './config/configuration';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
@@ -50,9 +51,9 @@ import { SpinModule } from './spin/spin.module';
       }),
     }),
     TypeOrmModule.forRootAsync({
-     imports: [ConfigModule],
-     inject: [ConfigService],
-     useFactory: (configService: ConfigService) => getTypeOrmConfig(configService),
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => getTypeOrmConfig(configService),
     }),
     TypeOrmModule.forFeature([
       User,
@@ -65,6 +66,7 @@ import { SpinModule } from './spin/spin.module';
       PlayerCardMetadata,
       Prediction,
       Spin,
+      SpinSession,
     ]),
     AuthModule,
     BetsModule,
@@ -73,7 +75,7 @@ import { SpinModule } from './spin/spin.module';
     PostsModule,
     PredictionsModule,
     SpinModule,
-    LeaderboardModule,
+    LeaderboardsModule,
   ],
   controllers: [],
   providers: [
@@ -83,4 +85,4 @@ import { SpinModule } from './spin/spin.module';
     },
   ],
 })
-export class AppModule {}
+export class AppModule { }

--- a/backend/src/migrations/1769293685000-add-spin-session-table.ts
+++ b/backend/src/migrations/1769293685000-add-spin-session-table.ts
@@ -1,0 +1,123 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class AddSpinSessionTable1769293685000 implements MigrationInterface {
+    name = 'AddSpinSessionTable1769293685000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Create reward_type enum
+        await queryRunner.query(`
+      CREATE TYPE "spin_session_reward_type_enum" AS ENUM ('xp', 'tokens', 'nft', 'bonus_spin', 'multiplier', 'none')
+    `);
+
+        // Create spin_session_status enum
+        await queryRunner.query(`
+      CREATE TYPE "spin_session_status_enum" AS ENUM ('pending', 'completed', 'failed')
+    `);
+
+        // Create spin_sessions table
+        await queryRunner.createTable(
+            new Table({
+                name: 'spin_sessions',
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'uuid',
+                        isPrimary: true,
+                        generationStrategy: 'uuid',
+                        default: 'uuid_generate_v4()',
+                    },
+                    {
+                        name: 'userId',
+                        type: 'uuid',
+                        isNullable: false,
+                    },
+                    {
+                        name: 'stakeAmount',
+                        type: 'decimal',
+                        precision: 18,
+                        scale: 8,
+                        isNullable: false,
+                    },
+                    {
+                        name: 'rewardType',
+                        type: 'spin_session_reward_type_enum',
+                        default: "'none'",
+                        isNullable: false,
+                    },
+                    {
+                        name: 'rewardValue',
+                        type: 'decimal',
+                        precision: 18,
+                        scale: 8,
+                        default: 0,
+                        isNullable: false,
+                    },
+                    {
+                        name: 'status',
+                        type: 'spin_session_status_enum',
+                        default: "'pending'",
+                        isNullable: false,
+                    },
+                    {
+                        name: 'txReference',
+                        type: 'varchar',
+                        length: '255',
+                        isNullable: true,
+                    },
+                    {
+                        name: 'createdAt',
+                        type: 'timestamp',
+                        default: 'now()',
+                        isNullable: false,
+                    },
+                ],
+            }),
+        );
+
+        // Create composite index on userId and createdAt for efficient filtering
+        await queryRunner.createIndex(
+            'spin_sessions',
+            new TableIndex({
+                name: 'IDX_spin_sessions_user_id_created_at',
+                columnNames: ['userId', 'createdAt'],
+            }),
+        );
+
+        // Create single index on userId for user-specific queries
+        await queryRunner.createIndex(
+            'spin_sessions',
+            new TableIndex({
+                name: 'IDX_spin_sessions_user_id',
+                columnNames: ['userId'],
+            }),
+        );
+
+        // Add foreign key constraint to users table
+        await queryRunner.query(`
+      ALTER TABLE "spin_sessions"
+      ADD CONSTRAINT "FK_spin_sessions_user_id"
+      FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+    `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Drop foreign key constraint
+        await queryRunner.query(
+            `ALTER TABLE "spin_sessions" DROP CONSTRAINT "FK_spin_sessions_user_id"`,
+        );
+
+        // Drop indexes
+        await queryRunner.dropIndex('spin_sessions', 'IDX_spin_sessions_user_id');
+        await queryRunner.dropIndex(
+            'spin_sessions',
+            'IDX_spin_sessions_user_id_created_at',
+        );
+
+        // Drop table
+        await queryRunner.dropTable('spin_sessions');
+
+        // Drop enums
+        await queryRunner.query(`DROP TYPE "spin_session_status_enum"`);
+        await queryRunner.query(`DROP TYPE "spin_session_reward_type_enum"`);
+    }
+}

--- a/backend/src/spin/dto/create-spin-session.dto.ts
+++ b/backend/src/spin/dto/create-spin-session.dto.ts
@@ -1,0 +1,35 @@
+import {
+    IsNumber,
+    IsString,
+    IsEnum,
+    IsOptional,
+    Min,
+    MaxLength,
+} from 'class-validator';
+import { Transform } from 'class-transformer';
+import { RewardType } from '../entities/spin-session.entity';
+
+/**
+ * DTO for creating a new SpinSession record.
+ */
+export class CreateSpinSessionDto {
+    @IsNumber()
+    @Min(0, { message: 'Stake amount must be non-negative' })
+    @Transform(({ value }) => parseFloat(value))
+    stakeAmount: number;
+
+    @IsEnum(RewardType)
+    @IsOptional()
+    rewardType?: RewardType;
+
+    @IsNumber()
+    @Min(0)
+    @IsOptional()
+    @Transform(({ value }) => (value !== undefined ? parseFloat(value) : undefined))
+    rewardValue?: number;
+
+    @IsString()
+    @IsOptional()
+    @MaxLength(255)
+    txReference?: string;
+}

--- a/backend/src/spin/entities/spin-session.entity.ts
+++ b/backend/src/spin/entities/spin-session.entity.ts
@@ -1,0 +1,85 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+  BeforeUpdate,
+} from 'typeorm';
+
+/**
+ * Enum representing the type of reward from a spin session.
+ */
+export enum RewardType {
+  XP = 'xp',
+  TOKENS = 'tokens',
+  NFT = 'nft',
+  BONUS_SPIN = 'bonus_spin',
+  MULTIPLIER = 'multiplier',
+  NONE = 'none',
+}
+
+/**
+ * Enum representing the status of a spin session.
+ */
+export enum SpinSessionStatus {
+  PENDING = 'pending',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+}
+
+/**
+ * SpinSession entity for tracking every spin attempt for auditability and fairness.
+ *
+ * Key Features:
+ * - Immutable after completion (status changes to completed/failed prevent further updates)
+ * - Indexed by userId and createdAt for efficient querying
+ * - Stores transaction reference for blockchain audit trail
+ */
+@Entity('spin_sessions')
+@Index(['userId', 'createdAt'])
+@Index(['userId'])
+export class SpinSession {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  @Index()
+  userId: string;
+
+  @Column('decimal', { precision: 18, scale: 8 })
+  stakeAmount: number;
+
+  @Column('enum', { enum: RewardType, default: RewardType.NONE })
+  rewardType: RewardType;
+
+  @Column('decimal', { precision: 18, scale: 8, default: 0 })
+  rewardValue: number;
+
+  @Column('enum', { enum: SpinSessionStatus, default: SpinSessionStatus.PENDING })
+  status: SpinSessionStatus;
+
+  @Column('varchar', { length: 255, nullable: true })
+  txReference: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  /**
+   * Prevents updates to completed or failed spin sessions to ensure immutability.
+   * This is a critical audit requirement - once a spin is finalized, it cannot be altered.
+   */
+  @BeforeUpdate()
+  preventUpdateAfterCompletion() {
+    // Note: This hook only fires on entity updates via TypeORM save()
+    // For complete protection, use service-layer validation as well
+    if (
+      this.status === SpinSessionStatus.COMPLETED ||
+      this.status === SpinSessionStatus.FAILED
+    ) {
+      throw new Error(
+        `Cannot update SpinSession ${this.id}: Session is immutable after ${this.status} status`,
+      );
+    }
+  }
+}

--- a/backend/src/spin/spin-session.service.spec.ts
+++ b/backend/src/spin/spin-session.service.spec.ts
@@ -1,0 +1,371 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { SpinSessionService } from './spin-session.service';
+import {
+    SpinSession,
+    SpinSessionStatus,
+    RewardType,
+} from './entities/spin-session.entity';
+import { CreateSpinSessionDto } from './dto/create-spin-session.dto';
+
+describe('SpinSessionService', () => {
+    let service: SpinSessionService;
+    let repository: Repository<SpinSession>;
+
+    const mockRepository = {
+        create: jest.fn(),
+        save: jest.fn(),
+        findOne: jest.fn(),
+        find: jest.fn(),
+    };
+
+    const mockUserId = 'user-123';
+    const mockSessionId = 'session-456';
+
+    const createMockSession = (overrides?: Partial<SpinSession>): SpinSession => ({
+        id: mockSessionId,
+        userId: mockUserId,
+        stakeAmount: 10,
+        rewardType: RewardType.NONE,
+        rewardValue: 0,
+        status: SpinSessionStatus.PENDING,
+        txReference: null,
+        createdAt: new Date(),
+        preventUpdateAfterCompletion: jest.fn(),
+        ...overrides,
+    });
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                SpinSessionService,
+                {
+                    provide: getRepositoryToken(SpinSession),
+                    useValue: mockRepository,
+                },
+            ],
+        }).compile();
+
+        service = module.get<SpinSessionService>(SpinSessionService);
+        repository = module.get<Repository<SpinSession>>(
+            getRepositoryToken(SpinSession),
+        );
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('create', () => {
+        it('should create a new spin session with default values', async () => {
+            const createDto: CreateSpinSessionDto = { stakeAmount: 10 };
+            const mockSession = createMockSession();
+
+            mockRepository.create.mockReturnValue(mockSession);
+            mockRepository.save.mockResolvedValue(mockSession);
+
+            const result = await service.create(mockUserId, createDto);
+
+            expect(mockRepository.create).toHaveBeenCalledWith({
+                userId: mockUserId,
+                stakeAmount: 10,
+                rewardType: RewardType.NONE,
+                rewardValue: 0,
+                status: SpinSessionStatus.PENDING,
+                txReference: null,
+            });
+            expect(mockRepository.save).toHaveBeenCalledWith(mockSession);
+            expect(result).toEqual(mockSession);
+        });
+
+        it('should create a spin session with provided reward type and value', async () => {
+            const createDto: CreateSpinSessionDto = {
+                stakeAmount: 25,
+                rewardType: RewardType.TOKENS,
+                rewardValue: 100,
+                txReference: 'tx-abc123',
+            };
+            const mockSession = createMockSession({
+                stakeAmount: 25,
+                rewardType: RewardType.TOKENS,
+                rewardValue: 100,
+                txReference: 'tx-abc123',
+            });
+
+            mockRepository.create.mockReturnValue(mockSession);
+            mockRepository.save.mockResolvedValue(mockSession);
+
+            const result = await service.create(mockUserId, createDto);
+
+            expect(mockRepository.create).toHaveBeenCalledWith({
+                userId: mockUserId,
+                stakeAmount: 25,
+                rewardType: RewardType.TOKENS,
+                rewardValue: 100,
+                status: SpinSessionStatus.PENDING,
+                txReference: 'tx-abc123',
+            });
+            expect(result.rewardType).toBe(RewardType.TOKENS);
+            expect(result.rewardValue).toBe(100);
+        });
+    });
+
+    describe('findById', () => {
+        it('should return a session when found', async () => {
+            const mockSession = createMockSession();
+            mockRepository.findOne.mockResolvedValue(mockSession);
+
+            const result = await service.findById(mockSessionId);
+
+            expect(mockRepository.findOne).toHaveBeenCalledWith({
+                where: { id: mockSessionId },
+            });
+            expect(result).toEqual(mockSession);
+        });
+
+        it('should return null when session not found', async () => {
+            mockRepository.findOne.mockResolvedValue(null);
+
+            const result = await service.findById('non-existent');
+
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('findByIdOrFail', () => {
+        it('should return session when found', async () => {
+            const mockSession = createMockSession();
+            mockRepository.findOne.mockResolvedValue(mockSession);
+
+            const result = await service.findByIdOrFail(mockSessionId);
+
+            expect(result).toEqual(mockSession);
+        });
+
+        it('should throw NotFoundException when session not found', async () => {
+            mockRepository.findOne.mockResolvedValue(null);
+
+            await expect(service.findByIdOrFail('non-existent')).rejects.toThrow(
+                NotFoundException,
+            );
+        });
+    });
+
+    describe('findByUserId', () => {
+        it('should return sessions for user ordered by createdAt DESC', async () => {
+            const sessions = [
+                createMockSession({ id: 'session-1' }),
+                createMockSession({ id: 'session-2' }),
+            ];
+            mockRepository.find.mockResolvedValue(sessions);
+
+            const result = await service.findByUserId(mockUserId);
+
+            expect(mockRepository.find).toHaveBeenCalledWith({
+                where: { userId: mockUserId },
+                order: { createdAt: 'DESC' },
+                take: 50,
+            });
+            expect(result).toEqual(sessions);
+        });
+
+        it('should respect custom limit parameter', async () => {
+            mockRepository.find.mockResolvedValue([]);
+
+            await service.findByUserId(mockUserId, 10);
+
+            expect(mockRepository.find).toHaveBeenCalledWith({
+                where: { userId: mockUserId },
+                order: { createdAt: 'DESC' },
+                take: 10,
+            });
+        });
+    });
+
+    describe('complete', () => {
+        it('should complete a pending session with reward details', async () => {
+            const mockSession = createMockSession();
+            const completedSession = createMockSession({
+                status: SpinSessionStatus.COMPLETED,
+                rewardType: RewardType.TOKENS,
+                rewardValue: 50,
+                txReference: 'tx-completed',
+            });
+
+            mockRepository.findOne.mockResolvedValue(mockSession);
+            mockRepository.save.mockResolvedValue(completedSession);
+
+            const result = await service.complete(
+                mockSessionId,
+                RewardType.TOKENS,
+                50,
+                'tx-completed',
+            );
+
+            expect(result.status).toBe(SpinSessionStatus.COMPLETED);
+            expect(result.rewardType).toBe(RewardType.TOKENS);
+            expect(result.rewardValue).toBe(50);
+        });
+
+        it('should throw BadRequestException when session is already completed', async () => {
+            const completedSession = createMockSession({
+                status: SpinSessionStatus.COMPLETED,
+            });
+            mockRepository.findOne.mockResolvedValue(completedSession);
+
+            await expect(
+                service.complete(mockSessionId, RewardType.XP, 10),
+            ).rejects.toThrow(BadRequestException);
+        });
+
+        it('should throw BadRequestException when session is failed', async () => {
+            const failedSession = createMockSession({
+                status: SpinSessionStatus.FAILED,
+            });
+            mockRepository.findOne.mockResolvedValue(failedSession);
+
+            await expect(
+                service.complete(mockSessionId, RewardType.XP, 10),
+            ).rejects.toThrow(BadRequestException);
+        });
+    });
+
+    describe('fail', () => {
+        it('should mark a pending session as failed', async () => {
+            const mockSession = createMockSession();
+            const failedSession = createMockSession({
+                status: SpinSessionStatus.FAILED,
+                txReference: 'tx-failed',
+            });
+
+            mockRepository.findOne.mockResolvedValue(mockSession);
+            mockRepository.save.mockResolvedValue(failedSession);
+
+            const result = await service.fail(mockSessionId, 'tx-failed');
+
+            expect(result.status).toBe(SpinSessionStatus.FAILED);
+        });
+
+        it('should throw BadRequestException when session is already completed', async () => {
+            const completedSession = createMockSession({
+                status: SpinSessionStatus.COMPLETED,
+            });
+            mockRepository.findOne.mockResolvedValue(completedSession);
+
+            await expect(service.fail(mockSessionId)).rejects.toThrow(
+                BadRequestException,
+            );
+        });
+    });
+
+    describe('setTxReference', () => {
+        it('should update txReference for pending session', async () => {
+            const mockSession = createMockSession();
+            const updatedSession = createMockSession({ txReference: 'new-tx-ref' });
+
+            mockRepository.findOne.mockResolvedValue(mockSession);
+            mockRepository.save.mockResolvedValue(updatedSession);
+
+            const result = await service.setTxReference(mockSessionId, 'new-tx-ref');
+
+            expect(result.txReference).toBe('new-tx-ref');
+        });
+
+        it('should throw BadRequestException for completed session', async () => {
+            const completedSession = createMockSession({
+                status: SpinSessionStatus.COMPLETED,
+            });
+            mockRepository.findOne.mockResolvedValue(completedSession);
+
+            await expect(
+                service.setTxReference(mockSessionId, 'new-ref'),
+            ).rejects.toThrow(BadRequestException);
+        });
+    });
+
+    describe('getStatistics', () => {
+        it('should return aggregate statistics', async () => {
+            const sessions = [
+                createMockSession({
+                    stakeAmount: 10,
+                    rewardValue: 25,
+                    status: SpinSessionStatus.COMPLETED,
+                    rewardType: RewardType.TOKENS,
+                }),
+                createMockSession({
+                    stakeAmount: 20,
+                    rewardValue: 0,
+                    status: SpinSessionStatus.FAILED,
+                    rewardType: RewardType.NONE,
+                }),
+                createMockSession({
+                    stakeAmount: 15,
+                    rewardValue: 0,
+                    status: SpinSessionStatus.PENDING,
+                    rewardType: RewardType.NONE,
+                }),
+            ];
+            mockRepository.find.mockResolvedValue(sessions);
+
+            const stats = await service.getStatistics();
+
+            expect(stats.totalSessions).toBe(3);
+            expect(stats.totalStaked).toBe(45);
+            expect(stats.totalRewards).toBe(25);
+            expect(stats.statusCounts[SpinSessionStatus.COMPLETED]).toBe(1);
+            expect(stats.statusCounts[SpinSessionStatus.FAILED]).toBe(1);
+            expect(stats.statusCounts[SpinSessionStatus.PENDING]).toBe(1);
+            expect(stats.rewardTypeCounts[RewardType.TOKENS]).toBe(1);
+            expect(stats.rewardTypeCounts[RewardType.NONE]).toBe(2);
+        });
+
+        it('should return zero counts when no sessions exist', async () => {
+            mockRepository.find.mockResolvedValue([]);
+
+            const stats = await service.getStatistics();
+
+            expect(stats.totalSessions).toBe(0);
+            expect(stats.totalStaked).toBe(0);
+            expect(stats.totalRewards).toBe(0);
+        });
+    });
+
+    describe('immutability enforcement', () => {
+        it('should prevent any modification to completed sessions', async () => {
+            const completedSession = createMockSession({
+                status: SpinSessionStatus.COMPLETED,
+            });
+            mockRepository.findOne.mockResolvedValue(completedSession);
+
+            // All modification operations should fail
+            await expect(
+                service.complete(mockSessionId, RewardType.XP, 10),
+            ).rejects.toThrow(/immutable/);
+
+            await expect(service.fail(mockSessionId)).rejects.toThrow(/immutable/);
+
+            await expect(
+                service.setTxReference(mockSessionId, 'new-ref'),
+            ).rejects.toThrow(/immutable/);
+        });
+
+        it('should prevent any modification to failed sessions', async () => {
+            const failedSession = createMockSession({
+                status: SpinSessionStatus.FAILED,
+            });
+            mockRepository.findOne.mockResolvedValue(failedSession);
+
+            await expect(
+                service.complete(mockSessionId, RewardType.XP, 10),
+            ).rejects.toThrow(/immutable/);
+
+            await expect(service.fail(mockSessionId)).rejects.toThrow(/immutable/);
+
+            await expect(
+                service.setTxReference(mockSessionId, 'new-ref'),
+            ).rejects.toThrow(/immutable/);
+        });
+    });
+});

--- a/backend/src/spin/spin-session.service.ts
+++ b/backend/src/spin/spin-session.service.ts
@@ -1,0 +1,236 @@
+import {
+    Injectable,
+    BadRequestException,
+    NotFoundException,
+    Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+    SpinSession,
+    SpinSessionStatus,
+    RewardType,
+} from './entities/spin-session.entity';
+import { CreateSpinSessionDto } from './dto/create-spin-session.dto';
+
+/**
+ * Service for managing SpinSession entities.
+ *
+ * Provides CRUD operations for spin session tracking with:
+ * - Immutability enforcement after completion
+ * - User-scoped queries
+ * - Audit-friendly logging
+ */
+@Injectable()
+export class SpinSessionService {
+    private readonly logger = new Logger(SpinSessionService.name);
+
+    constructor(
+        @InjectRepository(SpinSession)
+        private readonly spinSessionRepository: Repository<SpinSession>,
+    ) { }
+
+    /**
+     * Create a new spin session in pending status.
+     *
+     * @param userId - The user's ID
+     * @param createDto - The spin session creation data
+     * @returns The created SpinSession entity
+     */
+    async create(
+        userId: string,
+        createDto: CreateSpinSessionDto,
+    ): Promise<SpinSession> {
+        const spinSession = this.spinSessionRepository.create({
+            userId,
+            stakeAmount: createDto.stakeAmount,
+            rewardType: createDto.rewardType || RewardType.NONE,
+            rewardValue: createDto.rewardValue || 0,
+            status: SpinSessionStatus.PENDING,
+            txReference: createDto.txReference || null,
+        });
+
+        const saved = await this.spinSessionRepository.save(spinSession);
+        this.logger.log(`SpinSession created: ${saved.id} for user ${userId}`);
+        return saved;
+    }
+
+    /**
+     * Find a spin session by ID.
+     *
+     * @param id - The spin session ID
+     * @returns The SpinSession entity or null if not found
+     */
+    async findById(id: string): Promise<SpinSession | null> {
+        return this.spinSessionRepository.findOne({ where: { id } });
+    }
+
+    /**
+     * Find a spin session by ID, throwing if not found.
+     *
+     * @param id - The spin session ID
+     * @returns The SpinSession entity
+     * @throws NotFoundException if not found
+     */
+    async findByIdOrFail(id: string): Promise<SpinSession> {
+        const session = await this.findById(id);
+        if (!session) {
+            throw new NotFoundException(`SpinSession with ID ${id} not found`);
+        }
+        return session;
+    }
+
+    /**
+     * Get spin sessions for a specific user, ordered by createdAt descending.
+     *
+     * @param userId - The user's ID
+     * @param limit - Maximum number of records to return (default: 50)
+     * @returns Array of SpinSession entities
+     */
+    async findByUserId(userId: string, limit: number = 50): Promise<SpinSession[]> {
+        return this.spinSessionRepository.find({
+            where: { userId },
+            order: { createdAt: 'DESC' },
+            take: limit,
+        });
+    }
+
+    /**
+     * Complete a spin session with reward details.
+     * Once completed, the session becomes immutable.
+     *
+     * @param id - The spin session ID
+     * @param rewardType - The type of reward earned
+     * @param rewardValue - The value of the reward
+     * @param txReference - Optional transaction reference
+     * @returns The updated SpinSession entity
+     * @throws NotFoundException if session not found
+     * @throws BadRequestException if session is already finalized
+     */
+    async complete(
+        id: string,
+        rewardType: RewardType,
+        rewardValue: number,
+        txReference?: string,
+    ): Promise<SpinSession> {
+        const session = await this.findByIdOrFail(id);
+
+        this.assertMutable(session);
+
+        session.rewardType = rewardType;
+        session.rewardValue = rewardValue;
+        session.status = SpinSessionStatus.COMPLETED;
+        if (txReference) {
+            session.txReference = txReference;
+        }
+
+        const saved = await this.spinSessionRepository.save(session);
+        this.logger.log(
+            `SpinSession completed: ${id}, reward: ${rewardType} = ${rewardValue}`,
+        );
+        return saved;
+    }
+
+    /**
+     * Mark a spin session as failed.
+     * Once failed, the session becomes immutable.
+     *
+     * @param id - The spin session ID
+     * @param txReference - Optional transaction reference
+     * @returns The updated SpinSession entity
+     * @throws NotFoundException if session not found
+     * @throws BadRequestException if session is already finalized
+     */
+    async fail(id: string, txReference?: string): Promise<SpinSession> {
+        const session = await this.findByIdOrFail(id);
+
+        this.assertMutable(session);
+
+        session.status = SpinSessionStatus.FAILED;
+        if (txReference) {
+            session.txReference = txReference;
+        }
+
+        const saved = await this.spinSessionRepository.save(session);
+        this.logger.log(`SpinSession failed: ${id}`);
+        return saved;
+    }
+
+    /**
+     * Update the transaction reference for a pending session.
+     *
+     * @param id - The spin session ID
+     * @param txReference - The transaction reference to set
+     * @returns The updated SpinSession entity
+     * @throws NotFoundException if session not found
+     * @throws BadRequestException if session is already finalized
+     */
+    async setTxReference(id: string, txReference: string): Promise<SpinSession> {
+        const session = await this.findByIdOrFail(id);
+
+        this.assertMutable(session);
+
+        session.txReference = txReference;
+        return this.spinSessionRepository.save(session);
+    }
+
+    /**
+     * Get aggregate statistics for spin sessions.
+     *
+     * @returns Statistics object with totals and counts by status
+     */
+    async getStatistics(): Promise<{
+        totalSessions: number;
+        totalStaked: number;
+        totalRewards: number;
+        statusCounts: Record<SpinSessionStatus, number>;
+        rewardTypeCounts: Record<RewardType, number>;
+    }> {
+        const sessions = await this.spinSessionRepository.find();
+
+        const stats = {
+            totalSessions: sessions.length,
+            totalStaked: 0,
+            totalRewards: 0,
+            statusCounts: {
+                [SpinSessionStatus.PENDING]: 0,
+                [SpinSessionStatus.COMPLETED]: 0,
+                [SpinSessionStatus.FAILED]: 0,
+            },
+            rewardTypeCounts: {
+                [RewardType.XP]: 0,
+                [RewardType.TOKENS]: 0,
+                [RewardType.NFT]: 0,
+                [RewardType.BONUS_SPIN]: 0,
+                [RewardType.MULTIPLIER]: 0,
+                [RewardType.NONE]: 0,
+            },
+        };
+
+        for (const session of sessions) {
+            stats.totalStaked += Number(session.stakeAmount);
+            stats.totalRewards += Number(session.rewardValue);
+            stats.statusCounts[session.status]++;
+            stats.rewardTypeCounts[session.rewardType]++;
+        }
+
+        return stats;
+    }
+
+    /**
+     * Assert that a session can be modified (is still pending).
+     *
+     * @param session - The session to check
+     * @throws BadRequestException if session is completed or failed
+     */
+    private assertMutable(session: SpinSession): void {
+        if (
+            session.status === SpinSessionStatus.COMPLETED ||
+            session.status === SpinSessionStatus.FAILED
+        ) {
+            throw new BadRequestException(
+                `SpinSession ${session.id} is immutable after ${session.status} status`,
+            );
+        }
+    }
+}

--- a/backend/src/spin/spin.module.ts
+++ b/backend/src/spin/spin.module.ts
@@ -2,16 +2,18 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { SpinController } from './spin.controller';
 import { SpinService } from './spin.service';
+import { SpinSessionService } from './spin-session.service';
 import { Spin } from './entities/spin.entity';
+import { SpinSession } from './entities/spin-session.entity';
 import { WalletService } from '../wallet/wallet.service';
 import { Transaction } from '../transactions/entities/transaction.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Spin, Transaction]),
+    TypeOrmModule.forFeature([Spin, SpinSession, Transaction]),
   ],
   controllers: [SpinController],
-  providers: [SpinService, WalletService],
-  exports: [SpinService],
+  providers: [SpinService, SpinSessionService, WalletService],
+  exports: [SpinService, SpinSessionService],
 })
-export class SpinModule {}
+export class SpinModule { }


### PR DESCRIPTION
Implements SpinSession entity for tracking spin attempts per issue #51.

## Changes
- [SpinSession](cci:2://file:///c:/Users/Administrator/Renaissance-api/backend/src/spin/entities/spin-session.entity.ts:38:0-84:1) entity with: id, userId, stakeAmount, rewardType, rewardValue, status, txReference
- Database migration for `spin_sessions` table
- [SpinSessionService](cci:2://file:///c:/Users/Administrator/Renaissance-api/backend/src/spin/spin-session.service.ts:23:0-235:1) with CRUD operations
- Immutability enforcement after completion/failure
- Indexed by userId and createdAt
- 19 unit tests

## Files
- [spin-session.entity.ts](cci:7://file:///c:/Users/Administrator/Renaissance-api/backend/src/spin/entities/spin-session.entity.ts:0:0-0:0)
- [spin-session.service.ts](cci:7://file:///c:/Users/Administrator/Renaissance-api/backend/src/spin/spin-session.service.ts:0:0-0:0)
- [spin-session.service.spec.ts](cci:7://file:///c:/Users/Administrator/Renaissance-api/backend/src/spin/spin-session.service.spec.ts:0:0-0:0)
- [create-spin-session.dto.ts](cci:7://file:///c:/Users/Administrator/Renaissance-api/backend/src/spin/dto/create-spin-session.dto.ts:0:0-0:0)
- [1769293685000-add-spin-session-table.ts](cci:7://file:///c:/Users/Administrator/Renaissance-api/backend/src/migrations/1769293685000-add-spin-session-table.ts:0:0-0:0)
- [spin.module.ts](cci:7://file:///c:/Users/Administrator/Renaissance-api/backend/src/spin/spin.module.ts:0:0-0:0)
- [app.module.ts](cci:7://file:///c:/Users/Administrator/Renaissance-api/backend/src/app.module.ts:0:0-0:0)

Closes #51