### PR TITLE
feat: add UserLeaderboardStats entity

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -35,6 +35,7 @@ import { CacheConfigModule } from './common/cache/cache.module';
 import { AdminModule } from './admin/admin.module';
 
 import { LeaderboardModule } from './leaderboard/leaderboard.module';
+import { UserLeaderboardStats } from './leaderboard/entities/user-leaderboard-stats.entity';
 import { ReconciliationModule } from './reconciliation/reconciliation.module';
 
 
@@ -78,6 +79,7 @@ import { ReconciliationModule } from './reconciliation/reconciliation.module';
       FreeBetVoucher,
       Spin,
       SpinSession,
+      UserLeaderboardStats,
     ]),
     AuthModule,
     BetsModule,

--- a/backend/src/leaderboard/entities/user-leaderboard-stats.entity.ts
+++ b/backend/src/leaderboard/entities/user-leaderboard-stats.entity.ts
@@ -1,0 +1,59 @@
+import { Entity, Column, ManyToOne, JoinColumn, Index, Unique } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('user_leaderboard_stats')
+@Unique(['userId'])
+@Index(['totalStaked'])
+@Index(['totalEarnings'])
+@Index(['predictionAccuracy'])
+@Index(['longestWinStreak'])
+@Index(['totalWins'])
+@Index(['totalBets'])
+export class UserLeaderboardStats extends BaseEntity {
+    @Column({ name: 'user_id' })
+    userId: string;
+
+    @Column({
+        name: 'total_staked',
+        type: 'decimal',
+        precision: 18,
+        scale: 8,
+        default: 0,
+    })
+    totalStaked: number;
+
+    @Column({
+        name: 'total_earnings',
+        type: 'decimal',
+        precision: 18,
+        scale: 8,
+        default: 0,
+    })
+    totalEarnings: number;
+
+    @Column({ name: 'current_win_streak', default: 0 })
+    currentWinStreak: number;
+
+    @Column({ name: 'longest_win_streak', default: 0 })
+    longestWinStreak: number;
+
+    @Column({
+        name: 'prediction_accuracy',
+        type: 'decimal',
+        precision: 5,
+        scale: 2,
+        default: 0,
+    })
+    predictionAccuracy: number;
+
+    @Column({ name: 'total_bets', default: 0 })
+    totalBets: number;
+
+    @Column({ name: 'total_wins', default: 0 })
+    totalWins: number;
+
+    @ManyToOne(() => User, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'user_id' })
+    user: User;
+}

--- a/backend/src/leaderboard/leaderboard.module.ts
+++ b/backend/src/leaderboard/leaderboard.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { LeaderboardStats } from './entities/leaderboard-stats.entity';
+import { UserLeaderboardStats } from './entities/user-leaderboard-stats.entity';
 import { LeaderboardService } from './leaderboard.service';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([LeaderboardStats])],
+    imports: [TypeOrmModule.forFeature([LeaderboardStats, UserLeaderboardStats])],
     providers: [LeaderboardService],
     exports: [LeaderboardService],
 })


### PR DESCRIPTION
Created persisted aggregated leaderboard statistics per user with fields for totalStaked, totalEarnings, currentWinStreak, longestWinStreak, predictionAccuracy, totalBets, and totalWins.

- Unique constraint on userId (one row per user)
- Indexed sortable columns for fast leaderboard queries
- Proper decimal precision (18,8) for financial values
- Registered in LeaderboardModule and AppModule

Closes #46