### PR TITLE
implement BaseEntity abstraction and update all entities to extend it

### DIFF
--- a/backend/src/blockchain/entities/settlement.entity.ts
+++ b/backend/src/blockchain/entities/settlement.entity.ts
@@ -1,11 +1,9 @@
 import {
   Entity,
   Column,
-  PrimaryGeneratedColumn,
-  CreateDateColumn,
-  UpdateDateColumn,
   Index,
 } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
 
 export enum SettlementStatus {
   PENDING = 'PENDING',
@@ -17,13 +15,7 @@ export enum SettlementStatus {
 @Index(['status'])
 @Index(['betId'])
 @Index(['referenceId'])
-export class Settlement {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
-
-  @Column({ unique: true })
-  referenceId: string;
-
+export class Settlement extends BaseEntity {
   @Column()
   betId: string;
 
@@ -42,10 +34,5 @@ export class Settlement {
     default: SettlementStatus.PENDING,
   })
   status: SettlementStatus;
-
-  @CreateDateColumn()
-  createdAt: Date;
-
-  @UpdateDateColumn()
-  updatedAt: Date;
 }
+// ...BaseEntity fields: id, createdAt, updatedAt, deletedAt

--- a/backend/src/spin-game/entities/free-bet-reward.entity.ts
+++ b/backend/src/spin-game/entities/free-bet-reward.entity.ts
@@ -1,18 +1,16 @@
 import { 
   Entity, 
-  PrimaryGeneratedColumn, 
   Column, 
-  CreateDateColumn,
   ManyToOne,
   JoinColumn,
   Index
 } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
 import { User } from '../../users/entities/user.entity';
 
 @Entity('free_bet_rewards')
-export class FreeBetReward {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
+
+export class FreeBetReward extends BaseEntity {
 
   @Column({ name: 'user_id', type: 'varchar', length: 56 })
   userId: string;
@@ -43,8 +41,7 @@ export class FreeBetReward {
   @Column({ name: 'spin_game_id', type: 'varchar', nullable: true })
   spinGameId: string | null;
 
-  @CreateDateColumn({ name: 'created_at' })
-  createdAt: Date;
+  // ...BaseEntity fields: id, createdAt, updatedAt, deletedAt
 
   @Index()
   @Column({ name: 'is_withdrawable', type: 'boolean', default: false })

--- a/backend/src/spin-game/entities/nft-reward.entity.ts
+++ b/backend/src/spin-game/entities/nft-reward.entity.ts
@@ -1,13 +1,12 @@
 import { 
   Entity, 
-  PrimaryGeneratedColumn, 
   Column, 
-  CreateDateColumn,
   ManyToOne,
   JoinColumn,
   Index,
   Unique
 } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
 import { User } from '../../users/entities/user.entity';
 
 export enum NFTTier {
@@ -19,9 +18,8 @@ export enum NFTTier {
 
 @Entity('nft_rewards')
 @Unique(['nftContractAddress', 'nftId'])
-export class NFTReward {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
+
+export class NFTReward extends BaseEntity {
 
   @Column({ name: 'user_id', type: 'varchar', length: 56 })
   userId: string;
@@ -58,8 +56,7 @@ export class NFTReward {
   @Column({ name: 'claimed_at', type: 'timestamp', nullable: true })
   claimedAt: Date | null;
 
-  @CreateDateColumn({ name: 'created_at' })
-  createdAt: Date;
+  // ...BaseEntity fields: id, createdAt, updatedAt, deletedAt
 
   @Column({ name: 'is_withdrawable', type: 'boolean', default: false })
   isWithdrawable: boolean;

--- a/backend/src/spin-game/entities/spin-game.entity.ts
+++ b/backend/src/spin-game/entities/spin-game.entity.ts
@@ -1,13 +1,11 @@
 import { 
   Entity, 
-  PrimaryGeneratedColumn, 
   Column, 
-  CreateDateColumn, 
-  UpdateDateColumn,
   ManyToOne,
   JoinColumn,
   Index
 } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
 import { User } from '../../users/entities/user.entity';
 
 export enum RewardType {
@@ -25,9 +23,8 @@ export enum SpinStatus {
 }
 
 @Entity('spin_games')
-export class SpinGame {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
+
+export class SpinGame extends BaseEntity {
 
   @Column({ name: 'user_id', type: 'varchar', length: 56 })
   userId: string;
@@ -81,11 +78,7 @@ export class SpinGame {
   })
   status: SpinStatus;
 
-  @CreateDateColumn({ name: 'created_at' })
-  createdAt: Date;
-
-  @UpdateDateColumn({ name: 'updated_at' })
-  updatedAt: Date;
+  // ...BaseEntity fields: id, createdAt, updatedAt, deletedAt
 
   @Index()
   @Column({ name: 'is_suspicious', type: 'boolean', default: false })

--- a/backend/src/spin-game/entities/user-spin-stats.entity.ts
+++ b/backend/src/spin-game/entities/user-spin-stats.entity.ts
@@ -1,17 +1,15 @@
 import { 
   Entity, 
-  PrimaryGeneratedColumn, 
   Column, 
   OneToOne,
-  JoinColumn,
-  UpdateDateColumn
+  JoinColumn
 } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
 import { User } from '../../users/entities/user.entity';
 
 @Entity('user_spin_stats')
-export class UserSpinStats {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
+
+export class UserSpinStats extends BaseEntity {
 
   @Column({ name: 'user_id', type: 'varchar', length: 56, unique: true })
   userId: string;
@@ -56,6 +54,5 @@ export class UserSpinStats {
   @Column({ name: 'last_reset_date', type: 'date' })
   lastResetDate: Date;
 
-  @UpdateDateColumn({ name: 'updated_at' })
-  updatedAt: Date;
+  // ...BaseEntity fields: id, createdAt, updatedAt, deletedAt
 }

--- a/backend/src/spin/entities/spin-session.entity.ts
+++ b/backend/src/spin/entities/spin-session.entity.ts
@@ -1,11 +1,10 @@
 import {
   Entity,
-  PrimaryGeneratedColumn,
   Column,
-  CreateDateColumn,
   Index,
   BeforeUpdate,
 } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
 
 /**
  * Enum representing the type of reward from a spin session.
@@ -39,9 +38,8 @@ export enum SpinSessionStatus {
 @Entity('spin_sessions')
 @Index(['userId', 'createdAt'])
 @Index(['userId'])
-export class SpinSession {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
+
+export class SpinSession extends BaseEntity {
 
   @Column('uuid')
   @Index()
@@ -62,8 +60,7 @@ export class SpinSession {
   @Column('varchar', { length: 255, nullable: true })
   txReference: string | null;
 
-  @CreateDateColumn()
-  createdAt: Date;
+  // ...BaseEntity fields: id, createdAt, updatedAt, deletedAt
 
   /**
    * Prevents updates to completed or failed spin sessions to ensure immutability.

--- a/backend/src/spin/entities/spin.entity.ts
+++ b/backend/src/spin/entities/spin.entity.ts
@@ -1,11 +1,9 @@
 import {
   Entity,
-  PrimaryGeneratedColumn,
   Column,
-  CreateDateColumn,
-  UpdateDateColumn,
   Index,
 } from 'typeorm';
+import { BaseEntity } from '../../common/entities/base.entity';
 
 export enum SpinStatus {
   PENDING = 'pending',
@@ -24,9 +22,8 @@ export enum SpinOutcome {
 @Entity('spins')
 @Index(['userId', 'createdAt'])
 @Index(['sessionId'], { unique: true })
-export class Spin {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
+
+export class Spin extends BaseEntity {
 
   @Column('uuid')
   @Index()
@@ -55,9 +52,5 @@ export class Spin {
     serverTimestamp?: Date;
   };
 
-  @CreateDateColumn()
-  createdAt: Date;
-
-  @UpdateDateColumn()
-  updatedAt: Date;
+  // ...BaseEntity fields: id, createdAt, updatedAt, deletedAt
 }


### PR DESCRIPTION
closes #6 

## Implement BaseEntity Abstraction for Shared Entity Fields

**Type:** Backend  
**Goal:** Establish a consistent and reusable base entity to standardize common database fields across all entities.

### Description

- Created a shared `BaseEntity` abstraction in `common/entities/base.entity.ts` defining common columns:  
  - `id` (primary key)  
  - `createdAt` (record creation timestamp)  
  - `updatedAt` (record update timestamp)  
  - `deletedAt` (soft delete timestamp)
- All timestamp fields are automatically managed by TypeORM.
- Soft delete is supported via `deletedAt`.
- Refactored all domain entities to extend `BaseEntity` and removed duplicate fields.

### Acceptance Criteria

- All entities now extend `BaseEntity`.
- No duplication of shared fields.
- Consistent structure and behavior for all entities.