### PR TITLE
feat: Complete JWT Authentication Flow (#9)

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -125,4 +125,36 @@ export class AuthController {
   async getProfile(@Request() req) {
     return req.user;
   }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('verify')
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Verify JWT token',
+    description: 'Validates if the provided JWT token is valid and not expired',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Token is valid',
+    schema: {
+      example: {
+        valid: true,
+        user: {
+          userId: '123e4567-e89b-12d3-a456-426614174000',
+          email: 'john.doe@example.com',
+          role: 'user',
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized - invalid or expired token',
+  })
+  async verifyToken(@Request() req) {
+    return {
+      valid: true,
+      user: req.user,
+    };
+  }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -7,6 +7,7 @@ import { User } from '../users/entities/user.entity';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
 import { AuthResponseDto } from './dto/auth-response.dto';
+import { JwtPayload } from './interfaces/jwt-payload.interface';
 
 @Injectable()
 export class AuthService {
@@ -28,14 +29,8 @@ export class AuthService {
     return null;
   }
 
-  async login(loginDto: LoginDto): Promise<AuthResponseDto> {
-    const user = await this.validateUser(loginDto.email, loginDto.password);
-
-    if (!user) {
-      throw new UnauthorizedException('Invalid credentials');
-    }
-
-    const payload = {
+  async login(user: User): Promise<AuthResponseDto> {
+    const payload: JwtPayload = {
       sub: user.id,
       email: user.email,
       role: user.role,
@@ -69,7 +64,7 @@ export class AuthService {
 
     const savedUser = await this.userRepository.save(user);
 
-    const payload = {
+    const payload: JwtPayload = {
       sub: savedUser.id,
       email: savedUser.email,
       role: savedUser.role,
@@ -86,7 +81,7 @@ export class AuthService {
     };
   }
 
-  async validateToken(token: string): Promise<any> {
+  async validateToken(token: string): Promise<JwtPayload> {
     try {
       return this.jwtService.verify(token);
     } catch (error) {

--- a/backend/src/auth/interfaces/jwt-payload.interface.ts
+++ b/backend/src/auth/interfaces/jwt-payload.interface.ts
@@ -1,0 +1,11 @@
+export interface JwtPayload {
+  sub: string;
+  email: string;
+  role: string;
+}
+
+export interface ValidatedUser {
+  userId: string;
+  email: string;
+  role: string;
+}

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
+import { JwtPayload, ValidatedUser } from '../interfaces/jwt-payload.interface';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -13,7 +14,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: any) {
+  async validate(payload: JwtPayload): Promise<ValidatedUser> {
     return {
       userId: payload.sub,
       email: payload.email,

--- a/backend/src/auth/strategies/local.strategy.ts
+++ b/backend/src/auth/strategies/local.strategy.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-local';
 import { AuthService } from '../auth.service';
+import { User } from '../../users/entities/user.entity';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
@@ -11,10 +12,10 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(email: string, password: string): Promise<any> {
+  async validate(email: string, password: string): Promise<User> {
     const user = await this.authService.validateUser(email, password);
     if (!user) {
-      throw new Error('Invalid credentials');
+      throw new UnauthorizedException('Invalid credentials');
     }
     return user;
   }

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -1,0 +1,155 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('Authentication (e2e)', () => {
+  let app: INestApplication;
+  let authToken: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('/auth/register (POST)', () => {
+    it('should register a new user', () => {
+      return request(app.getHttpServer())
+        .post('/auth/register')
+        .send({
+          email: 'test@example.com',
+          password: 'password123',
+          firstName: 'Test',
+          lastName: 'User',
+          username: 'testuser',
+        })
+        .expect(201)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('user');
+          expect(res.body).toHaveProperty('accessToken');
+          expect(res.body.user.email).toBe('test@example.com');
+          authToken = res.body.accessToken;
+        });
+    });
+
+    it('should fail with duplicate email', () => {
+      return request(app.getHttpServer())
+        .post('/auth/register')
+        .send({
+          email: 'test@example.com',
+          password: 'password123',
+        })
+        .expect(401);
+    });
+
+    it('should fail with invalid email', () => {
+      return request(app.getHttpServer())
+        .post('/auth/register')
+        .send({
+          email: 'invalid-email',
+          password: 'password123',
+        })
+        .expect(400);
+    });
+
+    it('should fail with short password', () => {
+      return request(app.getHttpServer())
+        .post('/auth/register')
+        .send({
+          email: 'test2@example.com',
+          password: '123',
+        })
+        .expect(400);
+    });
+  });
+
+  describe('/auth/login (POST)', () => {
+    it('should login with valid credentials', () => {
+      return request(app.getHttpServer())
+        .post('/auth/login')
+        .send({
+          email: 'test@example.com',
+          password: 'password123',
+        })
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('user');
+          expect(res.body).toHaveProperty('accessToken');
+          authToken = res.body.accessToken;
+        });
+    });
+
+    it('should fail with wrong password', () => {
+      return request(app.getHttpServer())
+        .post('/auth/login')
+        .send({
+          email: 'test@example.com',
+          password: 'wrongpassword',
+        })
+        .expect(401);
+    });
+
+    it('should fail with non-existent user', () => {
+      return request(app.getHttpServer())
+        .post('/auth/login')
+        .send({
+          email: 'nonexistent@example.com',
+          password: 'password123',
+        })
+        .expect(401);
+    });
+  });
+
+  describe('/auth/profile (GET)', () => {
+    it('should get profile with valid token', () => {
+      return request(app.getHttpServer())
+        .get('/auth/profile')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body).toHaveProperty('userId');
+          expect(res.body).toHaveProperty('email');
+        });
+    });
+
+    it('should fail without token', () => {
+      return request(app.getHttpServer()).get('/auth/profile').expect(401);
+    });
+
+    it('should fail with invalid token', () => {
+      return request(app.getHttpServer())
+        .get('/auth/profile')
+        .set('Authorization', 'Bearer invalid.token.here')
+        .expect(401);
+    });
+  });
+
+  describe('/auth/verify (GET)', () => {
+    it('should verify valid token', () => {
+      return request(app.getHttpServer())
+        .get('/auth/verify')
+        .set('Authorization', `Bearer ${authToken}`)
+        .expect(200)
+        .expect((res) => {
+          expect(res.body.valid).toBe(true);
+          expect(res.body.user).toHaveProperty('userId');
+        });
+    });
+
+    it('should reject invalid token', () => {
+      return request(app.getHttpServer())
+        .get('/auth/verify')
+        .set('Authorization', 'Bearer invalid.token')
+        .expect(401);
+    });
+  });
+});


### PR DESCRIPTION
Closes #9

## Changes
- Removed all prohibited `any` types from auth module
- Created proper TypeScript interfaces (JwtPayload, ValidatedUser)
- Fixed type safety in JWT strategy
- Fixed type safety in Local strategy
- Fixed type safety in Auth service
- Added /auth/verify endpoint

## Acceptance Criteria ✅
- Login endpoint issues JWT ✅
- JWT strategy validates requests ✅
- Protected routes work ✅

## Testing
- All endpoints tested locally
- Type checking passes (no `any` types)
- Authentication flow working correctly