### PR TITLE
feat(#103): Rate-limited interaction layer for spin and staking

### DIFF
--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -11,6 +11,7 @@ import { Bet } from '../bets/entities/bet.entity';
 import { User } from '../users/entities/user.entity';
 import { Match } from '../matches/entities/match.entity';
 import { Transaction } from '../transactions/entities/transaction.entity';
+import { RateLimitModule } from '../rate-limit/rate-limit.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { Transaction } from '../transactions/entities/transaction.entity';
       Match,
       Transaction,
     ]),
+    RateLimitModule,
   ],
   controllers: [AdminController, EmergencyController],
   providers: [AdminService, EmergencyPauseService],

--- a/backend/src/admin/dto/rate-limit-config.dto.ts
+++ b/backend/src/admin/dto/rate-limit-config.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, Min, Max } from 'class-validator';
+
+export class UpdateRateLimitCooldownDto {
+  @ApiProperty({
+    description: 'Cooldown period in seconds between spin/stake actions per user',
+    example: 5,
+    minimum: 0,
+    maximum: 3600,
+  })
+  @IsInt()
+  @Min(0)
+  @Max(3600)
+  cooldownSeconds: number;
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -42,6 +42,7 @@ import { CorrelationIdMiddleware } from './common/middleware/correlation-id.midd
 import { SpinGameModule } from './spin-game/spin-game.module';
 import { Leaderboard } from './leaderboard/entities/leaderboard.entity';
 import { CircuitBreakerGuard } from './auth/guards/circuit-breaker.guard';
+import { RateLimitModule } from './rate-limit/rate-limit.module';
 
 
 @Module({
@@ -89,6 +90,7 @@ import { CircuitBreakerGuard } from './auth/guards/circuit-breaker.guard';
       UserLeaderboardStats,
     ]),
     SpinGameModule,
+    RateLimitModule,
     StakingModule,
     LeaderboardModule,
     FreeBetVouchersModule,

--- a/backend/src/bets/bets.controller.ts
+++ b/backend/src/bets/bets.controller.ts
@@ -36,6 +36,8 @@ import { OwnershipGuard } from '../common/guards/ownership.guard';
 import { UserRole } from '../users/entities/user.entity';
 import { Bet } from './entities/bet.entity';
 import { CriticalAction } from '../common/decorators/critical-action.decorator';
+import { RateLimitInteractionGuard } from '../rate-limit/guards/rate-limit-interaction.guard';
+import { RateLimitAction } from '../rate-limit/decorators/rate-limit-action.decorator';
 
 interface AuthenticatedRequest extends Request {
   user: {
@@ -54,6 +56,8 @@ export class BetsController {
 
   @Post()
   @CriticalAction('bets.place')
+  @UseGuards(RateLimitInteractionGuard)
+  @RateLimitAction('stake')
   @HttpCode(HttpStatus.CREATED)
   @ApiOperation({
     summary: 'Place a bet on a match',

--- a/backend/src/bets/bets.module.ts
+++ b/backend/src/bets/bets.module.ts
@@ -8,6 +8,7 @@ import { LeaderboardModule } from '../leaderboard/leaderboard.module';
 import { WalletModule } from '../wallet/wallet.module';
 import { FreeBetVouchersModule } from '../free-bet-vouchers/free-bet-vouchers.module';
 import { SpinModule } from '../spin/spin.module';
+import { RateLimitModule } from '../rate-limit/rate-limit.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { SpinModule } from '../spin/spin.module';
     WalletModule,
     FreeBetVouchersModule,
     SpinModule,
+    RateLimitModule,
   ],
   controllers: [BetsController],
   providers: [BetsService],

--- a/backend/src/bets/bets.service.ts
+++ b/backend/src/bets/bets.service.ts
@@ -22,6 +22,7 @@ import { FreeBetVoucherService } from '../free-bet-vouchers/free-bet-vouchers.se
 import { TransactionSource } from '../wallet/entities/balance-transaction.entity';
 import { BetPlacedEvent } from '../leaderboard/domain/events/bet-placed.event';
 import { BetSettledEvent } from '../leaderboard/domain/events/bet-settled.event';
+import { RateLimitInteractionService } from '../rate-limit/rate-limit-interaction.service';
 
 export interface PaginatedBets {
   data: Bet[];
@@ -42,6 +43,7 @@ export class BetsService {
     private readonly walletService: WalletService,
     private readonly eventBus: EventBus,
     private readonly freeBetVoucherService: FreeBetVoucherService,
+    private readonly rateLimitService: RateLimitInteractionService,
   ) {}
 
 
@@ -165,6 +167,8 @@ export class BetsService {
           createBetDto.predictedOutcome,
         ),
       );
+
+      await this.rateLimitService.recordInteraction(userId);
 
       return savedBet;
     } catch (error) {

--- a/backend/src/migrations/1769500000000-add-rate-limit-interaction-layer.ts
+++ b/backend/src/migrations/1769500000000-add-rate-limit-interaction-layer.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Rate-Limited Interaction Layer (#103)
+ * - user_last_interaction: last interaction timestamp per user (spin & staking)
+ * - rate_limit_config: admin-configurable cooldown period
+ */
+export class AddRateLimitInteractionLayer1769500000000
+  implements MigrationInterface
+{
+  name = 'AddRateLimitInteractionLayer1769500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "user_last_interaction" (
+        "user_id" uuid NOT NULL,
+        "last_interaction_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+        CONSTRAINT "PK_user_last_interaction_user_id" PRIMARY KEY ("user_id"),
+        CONSTRAINT "FK_user_last_interaction_user_id" FOREIGN KEY ("user_id")
+          REFERENCES "users"("id") ON DELETE CASCADE
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "rate_limit_config" (
+        "key" character varying(64) NOT NULL,
+        "value_seconds" integer NOT NULL,
+        "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+        "updated_by" character varying(64),
+        CONSTRAINT "PK_rate_limit_config_key" PRIMARY KEY ("key")
+      )
+    `);
+
+    await queryRunner.query(`
+      INSERT INTO "rate_limit_config" ("key", "value_seconds")
+      VALUES ('interaction_cooldown_seconds', 5)
+      ON CONFLICT ("key") DO NOTHING
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "user_last_interaction"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "rate_limit_config"`);
+  }
+}

--- a/backend/src/rate-limit/decorators/rate-limit-action.decorator.ts
+++ b/backend/src/rate-limit/decorators/rate-limit-action.decorator.ts
@@ -1,0 +1,10 @@
+import { SetMetadata } from '@nestjs/common';
+import { RATE_LIMIT_ACTION_KEY } from '../guards/rate-limit-interaction.guard';
+import { InteractionAction } from '../rate-limit-interaction.service';
+
+/**
+ * Mark a route as rate-limited for the given interaction action.
+ * Use with RateLimitInteractionGuard.
+ */
+export const RateLimitAction = (action: InteractionAction) =>
+  SetMetadata(RATE_LIMIT_ACTION_KEY, action);

--- a/backend/src/rate-limit/entities/index.ts
+++ b/backend/src/rate-limit/entities/index.ts
@@ -1,0 +1,5 @@
+export { UserLastInteraction } from './user-last-interaction.entity';
+export {
+  RateLimitConfig,
+  RATE_LIMIT_CONFIG_KEYS,
+} from './rate-limit-config.entity';

--- a/backend/src/rate-limit/entities/rate-limit-config.entity.ts
+++ b/backend/src/rate-limit/entities/rate-limit-config.entity.ts
@@ -1,0 +1,33 @@
+import {
+  Column,
+  Entity,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export const RATE_LIMIT_CONFIG_KEYS = {
+  INTERACTION_COOLDOWN_SECONDS: 'interaction_cooldown_seconds',
+} as const;
+
+/**
+ * Admin-configurable rate limit settings.
+ * Key: config name, value_seconds: cooldown in seconds.
+ */
+@Entity('rate_limit_config')
+export class RateLimitConfig {
+  @PrimaryColumn({ type: 'varchar', length: 64 })
+  key: string;
+
+  @Column({ name: 'value_seconds', type: 'int' })
+  valueSeconds: number;
+
+  @UpdateDateColumn({
+    name: 'updated_at',
+    type: 'timestamptz',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  updatedAt: Date;
+
+  @Column({ name: 'updated_by', type: 'varchar', length: 64, nullable: true })
+  updatedBy: string | null;
+}

--- a/backend/src/rate-limit/entities/user-last-interaction.entity.ts
+++ b/backend/src/rate-limit/entities/user-last-interaction.entity.ts
@@ -1,0 +1,23 @@
+import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn } from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+/**
+ * Tracks last interaction timestamp per user for rate limiting.
+ * Used to enforce cooldown on spin & staking (bet) endpoints.
+ */
+@Entity('user_last_interaction')
+export class UserLastInteraction {
+  @PrimaryColumn({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @Column({
+    name: 'last_interaction_at',
+    type: 'timestamptz',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  lastInteractionAt: Date;
+
+  @OneToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user?: User;
+}

--- a/backend/src/rate-limit/events/rate-limit-violation.event.ts
+++ b/backend/src/rate-limit/events/rate-limit-violation.event.ts
@@ -1,0 +1,13 @@
+/**
+ * Emitted when a user hits the interaction rate limit (spam / abuse).
+ * Fired before rejecting the request so consumers can log or audit.
+ */
+export class RateLimitViolationEvent {
+  constructor(
+    public readonly userId: string,
+    public readonly action: 'spin' | 'spin_game' | 'stake',
+    public readonly requestedAt: Date,
+    public readonly cooldownSeconds: number,
+    public readonly nextAllowedAt: Date,
+  ) {}
+}

--- a/backend/src/rate-limit/guards/rate-limit-interaction.guard.ts
+++ b/backend/src/rate-limit/guards/rate-limit-interaction.guard.ts
@@ -1,0 +1,41 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RateLimitInteractionService, InteractionAction } from '../rate-limit-interaction.service';
+
+export const RATE_LIMIT_ACTION_KEY = 'rate_limit_action';
+
+/**
+ * Guard that enforces interaction rate limit before spin / stake endpoints.
+ * Use with @SetMetadata(RATE_LIMIT_ACTION_KEY, 'spin' | 'spin_game' | 'stake').
+ */
+@Injectable()
+export class RateLimitInteractionGuard implements CanActivate {
+  constructor(
+    private readonly rateLimitService: RateLimitInteractionService,
+    private readonly reflector: Reflector,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const action = this.reflector.get<InteractionAction | undefined>(
+      RATE_LIMIT_ACTION_KEY,
+      context.getHandler(),
+    );
+    if (!action) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const userId: string | undefined =
+      request.user?.userId ?? request.user?.id;
+    if (!userId) {
+      return true; // Auth guard will handle unauthenticated
+    }
+
+    await this.rateLimitService.checkAndEnforce(userId, action);
+    return true;
+  }
+}

--- a/backend/src/rate-limit/listeners/rate-limit-violation.listener.ts
+++ b/backend/src/rate-limit/listeners/rate-limit-violation.listener.ts
@@ -1,0 +1,20 @@
+import { EventsHandler, IEventHandler } from '@nestjs/cqrs';
+import { Logger } from '@nestjs/common';
+import { RateLimitViolationEvent } from '../events/rate-limit-violation.event';
+
+/**
+ * Logs rate limit violations (and can be extended to write to audit).
+ */
+@EventsHandler(RateLimitViolationEvent)
+export class RateLimitViolationListener
+  implements IEventHandler<RateLimitViolationEvent>
+{
+  private readonly logger = new Logger(RateLimitViolationListener.name);
+
+  async handle(event: RateLimitViolationEvent): Promise<void> {
+    this.logger.warn(
+      `Rate limit violation: userId=${event.userId} action=${event.action} ` +
+        `cooldown=${event.cooldownSeconds}s nextAllowedAt=${event.nextAllowedAt.toISOString()}`,
+    );
+  }
+}

--- a/backend/src/rate-limit/rate-limit-interaction.service.ts
+++ b/backend/src/rate-limit/rate-limit-interaction.service.ts
@@ -1,0 +1,127 @@
+import {
+  ForbiddenException,
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { EventBus } from '@nestjs/cqrs';
+import {
+  UserLastInteraction,
+  RateLimitConfig,
+  RATE_LIMIT_CONFIG_KEYS,
+} from './entities';
+import { RateLimitViolationEvent } from './events/rate-limit-violation.event';
+
+export type InteractionAction = 'spin' | 'spin_game' | 'stake';
+
+const CONFIG_KEY = RATE_LIMIT_CONFIG_KEYS.INTERACTION_COOLDOWN_SECONDS;
+
+/**
+ * Rate-Limited Interaction Layer (#103).
+ * Tracks last interaction per user, enforces admin-configurable cooldown,
+ * applies to spin & staking endpoints. Emits violation event on rejection.
+ */
+@Injectable()
+export class RateLimitInteractionService {
+  private readonly logger = new Logger(RateLimitInteractionService.name);
+
+  constructor(
+    @InjectRepository(UserLastInteraction)
+    private readonly lastInteractionRepo: Repository<UserLastInteraction>,
+    @InjectRepository(RateLimitConfig)
+    private readonly configRepo: Repository<RateLimitConfig>,
+    private readonly eventBus: EventBus,
+  ) {}
+
+  /**
+   * Returns cooldown in seconds (admin-configurable). Default 5.
+   */
+  async getCooldownSeconds(): Promise<number> {
+    const row = await this.configRepo.findOne({
+      where: { key: CONFIG_KEY },
+    });
+    return row?.valueSeconds ?? 5;
+  }
+
+  /**
+   * Admin: set cooldown period in seconds.
+   */
+  async setCooldownSeconds(
+    valueSeconds: number,
+    updatedBy: string,
+  ): Promise<{ cooldownSeconds: number }> {
+    if (valueSeconds < 0) {
+      throw new ForbiddenException('Cooldown must be >= 0');
+    }
+    await this.configRepo.upsert(
+      {
+        key: CONFIG_KEY,
+        valueSeconds,
+        updatedBy,
+      },
+      { conflictPaths: ['key'] },
+    );
+    return { cooldownSeconds: valueSeconds };
+  }
+
+  /**
+   * Check if user is allowed to perform the action (within cooldown).
+   * If not allowed: emits RateLimitViolationEvent and throws.
+   * Call recordInteraction() after a successful action.
+   */
+  async checkAndEnforce(
+    userId: string,
+    action: InteractionAction,
+  ): Promise<void> {
+    const cooldownSeconds = await this.getCooldownSeconds();
+    if (cooldownSeconds <= 0) {
+      return;
+    }
+
+    const row = await this.lastInteractionRepo.findOne({
+      where: { userId },
+    });
+    if (!row) {
+      return;
+    }
+
+    const now = new Date();
+    const elapsedMs = now.getTime() - row.lastInteractionAt.getTime();
+    const cooldownMs = cooldownSeconds * 1000;
+
+    if (elapsedMs < cooldownMs) {
+      const nextAllowedAt = new Date(
+        row.lastInteractionAt.getTime() + cooldownMs,
+      );
+      this.eventBus.publish(
+        new RateLimitViolationEvent(
+          userId,
+          action,
+          now,
+          cooldownSeconds,
+          nextAllowedAt,
+        ),
+      );
+      this.logger.warn(
+        `Rate limit violation: userId=${userId} action=${action} cooldown=${cooldownSeconds}s nextAllowedAt=${nextAllowedAt.toISOString()}`,
+      );
+      throw new ForbiddenException(
+        `Please wait ${Math.ceil((cooldownMs - elapsedMs) / 1000)} seconds before another ${action} action.`,
+      );
+    }
+  }
+
+  /**
+   * Record that the user performed an interaction (call after successful spin/bet).
+   */
+  async recordInteraction(userId: string): Promise<void> {
+    await this.lastInteractionRepo.upsert(
+      {
+        userId,
+        lastInteractionAt: new Date(),
+      },
+      { conflictPaths: ['userId'] },
+    );
+  }
+}

--- a/backend/src/rate-limit/rate-limit.module.ts
+++ b/backend/src/rate-limit/rate-limit.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CqrsModule } from '@nestjs/cqrs';
+import {
+  UserLastInteraction,
+  RateLimitConfig,
+} from './entities';
+import { RateLimitInteractionService } from './rate-limit-interaction.service';
+import { RateLimitInteractionGuard } from './guards/rate-limit-interaction.guard';
+import { RateLimitViolationListener } from './listeners/rate-limit-violation.listener';
+
+@Module({
+  imports: [
+    CqrsModule,
+    TypeOrmModule.forFeature([UserLastInteraction, RateLimitConfig]),
+  ],
+  providers: [
+    RateLimitInteractionService,
+    RateLimitInteractionGuard,
+    RateLimitViolationListener,
+  ],
+  exports: [RateLimitInteractionService, RateLimitInteractionGuard],
+})
+export class RateLimitModule {}

--- a/backend/src/spin-game/spin-game.controller.ts
+++ b/backend/src/spin-game/spin-game.controller.ts
@@ -17,6 +17,8 @@ import {
 } from './dto/spin-game.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CriticalAction } from '../common/decorators/critical-action.decorator';
+import { RateLimitInteractionGuard } from '../rate-limit/guards/rate-limit-interaction.guard';
+import { RateLimitAction } from '../rate-limit/decorators/rate-limit-action.decorator';
 
 @ApiTags('Spin Game')
 @Controller('spin-game')
@@ -38,6 +40,8 @@ export class SpinGameController {
 
   @Post('spin')
   @CriticalAction('spin_game.spin')
+  @UseGuards(RateLimitInteractionGuard)
+  @RateLimitAction('spin_game')
   @ApiOperation({ summary: 'Execute a spin' })
   @ApiResponse({ 
     status: HttpStatus.CREATED, 

--- a/backend/src/spin-game/spin-game.module.ts
+++ b/backend/src/spin-game/spin-game.module.ts
@@ -11,6 +11,7 @@ import {
   FreeBetReward, 
   NFTReward 
 } from './entities';
+import { RateLimitModule } from '../rate-limit/rate-limit.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import {
     ]),
     ConfigModule,
     JwtModule,
+    RateLimitModule,
   ],
   controllers: [SpinGameController],
   providers: [SpinGameService, SpinGameRepository],

--- a/backend/src/spin-game/spin-game.service.ts
+++ b/backend/src/spin-game/spin-game.service.ts
@@ -11,6 +11,7 @@ import {
   SpinGameConfig 
 } from './config/spin-game.config';
 import { SpinGameRepository } from './repositories/spin-game.repository';
+import { RateLimitInteractionService } from '../rate-limit/rate-limit-interaction.service';
 import { 
   SpinRequestDto, 
   SpinResultDto, 
@@ -37,6 +38,7 @@ export class SpinGameService {
     private readonly spinGameRepo: SpinGameRepository,
     private readonly configService: ConfigService,
     private readonly dataSource: DataSource,
+    private readonly rateLimitService: RateLimitInteractionService,
   ) {}
 
   /**
@@ -177,6 +179,8 @@ export class SpinGameService {
 
     // Check for suspicious activity
     await this.checkForSuspiciousActivity(userId, spinResult);
+
+    await this.rateLimitService.recordInteraction(userId);
 
     return {
       spinId: spinResult.id,

--- a/backend/src/spin/spin.controller.ts
+++ b/backend/src/spin/spin.controller.ts
@@ -20,6 +20,8 @@ import { SpinService } from './spin.service';
 import { CreateSpinDto } from './dto/create-spin.dto';
 import { SpinResultDto } from './dto/spin-result.dto';
 import { CriticalAction } from '../common/decorators/critical-action.decorator';
+import { RateLimitInteractionGuard } from '../rate-limit/guards/rate-limit-interaction.guard';
+import { RateLimitAction } from '../rate-limit/decorators/rate-limit-action.decorator';
 
 /**
  * Controller for secure spin operations with provably fair randomness
@@ -40,6 +42,8 @@ export class SpinController {
 
   @Post()
   @CriticalAction('spin.execute')
+  @UseGuards(RateLimitInteractionGuard)
+  @RateLimitAction('spin')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({
     summary: 'Execute a spin',

--- a/backend/src/spin/spin.module.ts
+++ b/backend/src/spin/spin.module.ts
@@ -8,11 +8,13 @@ import { SpinSession } from './entities/spin-session.entity';
 import { WalletModule } from '../wallet/wallet.module';
 import { Transaction } from '../transactions/entities/transaction.entity';
 import { User } from 'src/users/entities/user.entity';
+import { RateLimitModule } from '../rate-limit/rate-limit.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([User, Spin, SpinSession, Transaction]),
     WalletModule,
+    RateLimitModule,
   ],
   controllers: [SpinController],
   providers: [SpinService, SpinSessionService],

--- a/backend/src/spin/spin.service.ts
+++ b/backend/src/spin/spin.service.ts
@@ -12,6 +12,7 @@ import { CreateSpinDto } from './dto/create-spin.dto';
 import { SpinResultDto } from './dto/spin-result.dto';
 import { WalletService } from '../wallet/wallet.service';
 import { TransactionType } from '../transactions/entities/transaction.entity';
+import { RateLimitInteractionService } from '../rate-limit/rate-limit-interaction.service';
 
 /**
  * Interface defining the structure of weighted outcomes for the spin wheel.
@@ -71,6 +72,7 @@ export class SpinService {
     private readonly spinRepository: Repository<Spin>,
     private readonly dataSource: DataSource,
     private readonly walletService: WalletService,
+    private readonly rateLimitService: RateLimitInteractionService,
   ) {
     // Validate configuration on startup to prevent runtime errors
     if (this.totalWeight !== 1000) {
@@ -199,6 +201,8 @@ export class SpinService {
       }
 
       await queryRunner.commitTransaction();
+
+      await this.rateLimitService.recordInteraction(userId);
 
       this.logger.log(
         `Spin executed successfully: ${savedSpin.id}, outcome: ${outcome}, payout: ${payoutAmount}`,


### PR DESCRIPTION
- Track last interaction timestamp per user (user_last_interaction table)
- Enforce admin-configurable cooldown (rate_limit_config table)
- Apply to spin, spin-game, and place-bet endpoints via guard
- Emit RateLimitViolationEvent on rejection; listener logs violations
- Admin GET/PATCH /admin/rate-limit for cooldown config


close #103 