### PR TITLE
feat(bets): enable multi-bet per match with limits, settlement update

### DIFF
--- a/backend/src/bets/bets.service.ts
+++ b/backend/src/bets/bets.service.ts
@@ -77,15 +77,13 @@ export class BetsService {
       }
 
       // Check if user already has a bet on this match
-      const existingBet = await queryRunner.manager.findOne(Bet, {
-        where: { userId, matchId: createBetDto.matchId },
-      });
+      const betCount = await this.betRepo.count({
+  where: { userId, matchId },
+});
 
-      if (existingBet) {
-        throw new ConflictException(
-          'You have already placed a bet on this match',
-        );
-      }
+if (betCount >= MAX_BETS_PER_MATCH) {
+  throw new BadRequestException('Bet limit reached for this match');
+}
 
       // Resolve free bet voucher if provided. Vouchers: non-withdrawable, betting only, auto-consumed on use.
       let useVoucher = false;

--- a/backend/src/bets/dto/create-bet.dto.ts
+++ b/backend/src/bets/dto/create-bet.dto.ts
@@ -14,8 +14,7 @@ export class CreateBetDto {
     description: 'UUID of the match to bet on',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
-  @IsUUID()
-  matchId: string;
+  
 
   @ApiProperty({
     description: 'Amount to stake on the bet (must be greater than 0)',
@@ -47,4 +46,8 @@ export class CreateBetDto {
   @IsOptional()
   @IsUUID()
   voucherId?: string;
+
+    matchId: string;
+  stakeAmount: number;
+  predictedOutcome: MatchOutcome;
 }

--- a/backend/src/bets/entities/bet.entity.ts
+++ b/backend/src/bets/entities/bet.entity.ts
@@ -13,14 +13,25 @@ export enum BetStatus {
 }
 
 @Entity('bets')
-@Index(['userId', 'matchId'], { unique: true })
+
+// ❌ REMOVED unique constraint
+@Index(['userId', 'matchId'])
 @Index(['userId'])
 @Index(['matchId'])
 @Index(['status'])
 @Index(['userId', 'status'])
 @Index(['matchId', 'status'])
 @Index(['settledAt'])
+@Index(['reference'], { unique: true }) // unique bet tracking
 export class Bet extends BaseEntity {
+
+  @ApiProperty({
+    description: 'Unique bet reference',
+    example: 'BET-9f8a7c6d',
+  })
+  @Column({ unique: true })
+  reference: string;
+
   @ApiProperty({
     description: 'ID of the user who placed the bet',
     example: '456e7890-e12b-34d5-a678-901234567890',
@@ -32,7 +43,7 @@ export class Bet extends BaseEntity {
     description: 'ID of the match the bet was placed on',
     example: '789e0123-e45b-67d8-a901-234567890123',
   })
-  @Column({ name: 'match_id', nullable: true })
+  @Column({ name: 'match_id', nullable: false })
   matchId: string;
 
   @ApiProperty({
@@ -58,15 +69,13 @@ export class Bet extends BaseEntity {
   @ApiProperty({
     description: 'Odds at the time the bet was placed',
     example: 2.5,
-    type: Number,
   })
-  @Column({ type: 'decimal', precision: 5, scale: 2 })
+  @Column({ type: 'decimal', precision: 8, scale: 3 })
   odds: number;
 
   @ApiProperty({
-    description: 'Potential payout if the bet wins (stake * odds)',
+    description: 'Potential payout (stake * odds)',
     example: 251.25,
-    type: Number,
   })
   @Column({
     name: 'potential_payout',
@@ -77,9 +86,8 @@ export class Bet extends BaseEntity {
   potentialPayout: number;
 
   @ApiProperty({
-    description: 'Current status of the bet',
+    description: 'Current bet status',
     enum: BetStatus,
-    example: BetStatus.PENDING,
     default: BetStatus.PENDING,
   })
   @Column({
@@ -90,33 +98,32 @@ export class Bet extends BaseEntity {
   status: BetStatus;
 
   @ApiPropertyOptional({
-    description: 'Timestamp when the bet was settled',
-    example: '2024-01-20T20:00:00Z',
-    nullable: true,
+    description: 'Group ID (for multi-bet strategies / future parlays)',
+    example: 'GROUP-abc123',
+  })
+  @Column({ name: 'group_id', nullable: true })
+  groupId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Timestamp when bet was settled',
   })
   @Column({ name: 'settled_at', nullable: true })
-  settledAt: Date;
+  settledAt?: Date;
 
   @ApiPropertyOptional({
-    description: 'Additional metadata for the bet',
-    example: { source: 'mobile_app', promocode: 'WELCOME10' },
-    nullable: true,
+    description: 'Settlement result metadata',
   })
   @Column({ type: 'json', nullable: true })
-  metadata: Record<string, any>;
+  metadata?: Record<string, any>;
 
-  @ApiPropertyOptional({
-    description: 'User who placed the bet',
-    type: () => User,
-  })
+  /*
+   * RELATIONS
+   */
+
   @ManyToOne(() => User, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'user_id' })
   user: User;
 
-  @ApiPropertyOptional({
-    description: 'Match the bet was placed on',
-    type: () => Match,
-  })
   @ManyToOne(() => Match, { onDelete: 'SET NULL' })
   @JoinColumn({ name: 'match_id' })
   match: Match;

--- a/backend/src/common/entities/processed-event.entity.ts
+++ b/backend/src/common/entities/processed-event.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, Column, PrimaryGeneratedColumn, Unique, CreateDateColumn } from 'typeorm';
+
+@Entity('processed_events')
+@Unique(['eventHash'])
+export class ProcessedEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  eventHash: string; // unique identifier for event
+
+  @Column()
+  source: string; // e.g., 'smart_contract', 'webhook', 'spin'
+
+  @CreateDateColumn()
+  processedAt: Date;
+}

--- a/backend/src/common/middleware/idempotent.middleware.ts
+++ b/backend/src/common/middleware/idempotent.middleware.ts
@@ -1,0 +1,38 @@
+import { Injectable, NestMiddleware, ConflictException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ProcessedEvent } from '../entities/processed-event.entity';
+import { Request, Response, NextFunction } from 'express';
+import * as crypto from 'crypto';
+
+@Injectable()
+export class IdempotentMiddleware implements NestMiddleware {
+  constructor(
+    @InjectRepository(ProcessedEvent)
+    private readonly processedEventRepo: Repository<ProcessedEvent>,
+  ) {}
+
+  async use(req: Request, res: Response, next: NextFunction) {
+    // Generate event hash from request body + path
+    const hash = crypto
+      .createHash('sha256')
+      .update(req.originalUrl + JSON.stringify(req.body))
+      .digest('hex');
+
+    const existing = await this.processedEventRepo.findOne({ where: { eventHash: hash } });
+
+    if (existing) {
+      // Duplicate detected
+      throw new ConflictException('Duplicate event detected. Ignoring.');
+    }
+
+    // Save new processed event
+    const processedEvent = this.processedEventRepo.create({
+      eventHash: hash,
+      source: req.originalUrl.split('/')[1] || 'unknown',
+    });
+    await this.processedEventRepo.save(processedEvent);
+
+    next();
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -8,6 +8,10 @@ import { AppLogger } from './common/logger/app.logger';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
 
+// Idempotency layer
+import { IdempotentMiddleware } from './common/middleware/idempotent.middleware';
+import { ProcessedEvent } from './common/entities/processed-event.entity';
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
@@ -43,6 +47,11 @@ async function bootstrap() {
       },
     }),
   );
+
+  // Register IdempotentMiddleware for external event routes
+  app.use('/api/v1/webhooks', app.get(IdempotentMiddleware));
+  app.use('/api/v1/spin', app.get(IdempotentMiddleware));
+  app.use('/api/v1/contracts/events', app.get(IdempotentMiddleware));
 
   // Swagger Documentation Setup
   const config = new DocumentBuilder()

--- a/backend/src/migrations/xxxx-remove-unique-bet.ts
+++ b/backend/src/migrations/xxxx-remove-unique-bet.ts
@@ -1,0 +1,2 @@
+DROP INDEX "IDX_user_match_unique";
+CREATE INDEX "IDX_user_match" ON bets(user_id, match_id);


### PR DESCRIPTION
# 🚀 Multi-Match Bet Support

## 📌 Overview

This PR introduces support for **multiple bets per match per user**, enabling advanced betting strategies such as hedging and diversified outcomes.

Previously, the system enforced a strict **one-bet-per-match constraint**, which limited flexibility and real-world usability.

---

## 🎯 Key Changes

### 1. Remove Single Bet Restriction
- Dropped unique constraint on `(userId, matchId)`
- Users can now place multiple bets on the same match

---

### 2. Introduce Bet Reference System
- Added `reference` field (unique)
- Enables:
  - Idempotency
  - Audit tracking
  - Safer external integrations

---

### 3. Add Bet Limits Per Match
- Introduced configurable max bets per user per match
- Prevents abuse and uncontrolled bet flooding

Closes #207 