### PR TITLE
feat: Enhance cache service, add Redis caching, and improve free-bet-…

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -50,6 +50,7 @@ import { RateLimitGuard } from './common/guards/rate-limit.guard';
 import { TreasuryModule } from './treasury/treasury.module';
 import { StakingModule } from './stake/staking.module';
 import { PlayerModule } from './player/player.module';
+import { DatabaseModule } from './database/database.module';
 
 @Module({
   imports: [
@@ -96,6 +97,7 @@ import { PlayerModule } from './player/player.module';
       Team,
       Comment,
     ]),
+    DatabaseModule,
     RateLimitModule,
     AuthModule,
     MatchesModule,

--- a/backend/src/common/cache/cache.service.spec.ts
+++ b/backend/src/common/cache/cache.service.spec.ts
@@ -1,0 +1,66 @@
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CacheService } from './cache.service';
+
+describe('CacheService', () => {
+  const createService = async (cacheManagerMock: Record<string, unknown>) => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CacheService,
+        {
+          provide: CACHE_MANAGER,
+          useValue: cacheManagerMock,
+        },
+      ],
+    }).compile();
+
+    return module.get<CacheService>(CacheService);
+  };
+
+  it('clears using cacheManager.reset when available', async () => {
+    const reset = jest.fn().mockResolvedValue(undefined);
+    const clear = jest.fn().mockResolvedValue(undefined);
+    const service = await createService({ reset, clear });
+
+    await service.clear();
+
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  it('falls back to cacheManager.clear when reset is unavailable', async () => {
+    const clear = jest.fn().mockResolvedValue(undefined);
+    const service = await createService({ clear });
+
+    await service.clear();
+
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses store.clear when top-level methods are unavailable', async () => {
+    const storeClear = jest.fn().mockResolvedValue(undefined);
+    const service = await createService({
+      store: {
+        clear: storeClear,
+      },
+    });
+
+    await service.clear();
+
+    expect(storeClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears every backend store in multi-store mode', async () => {
+    const firstStoreReset = jest.fn().mockResolvedValue(undefined);
+    const secondStoreClear = jest.fn().mockResolvedValue(undefined);
+
+    const service = await createService({
+      stores: [{ reset: firstStoreReset }, { clear: secondStoreClear }],
+    });
+
+    await service.clear();
+
+    expect(firstStoreReset).toHaveBeenCalledTimes(1);
+    expect(secondStoreClear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/common/cache/cache.service.ts
+++ b/backend/src/common/cache/cache.service.ts
@@ -26,9 +26,7 @@ export class CacheService implements OnModuleInit {
   private missCount = 0;
   private readonly MAX_CACHE_ENTRIES = 1000;
 
-  constructor(
-    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
-  ) {}
+  constructor(@Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {}
 
   onModuleInit() {
     this.logger.log('CacheService initialized');
@@ -41,7 +39,7 @@ export class CacheService implements OnModuleInit {
   async get<T>(key: string): Promise<T | null> {
     try {
       const value = await this.cacheManager.get<T>(key);
-      
+
       if (value !== undefined && value !== null) {
         this.hitCount++;
         this.logger.debug(`Cache HIT: ${key}`);
@@ -60,11 +58,7 @@ export class CacheService implements OnModuleInit {
   /**
    * Set value in cache with TTL
    */
-  async set<T>(
-    key: string,
-    value: T,
-    ttl?: number,
-  ): Promise<void> {
+  async set<T>(key: string, value: T, ttl?: number): Promise<void> {
     try {
       await this.cacheManager.set(key, value, ttl);
       this.logger.debug(`Cache SET: ${key}`);
@@ -107,14 +101,14 @@ export class CacheService implements OnModuleInit {
     ttl?: number,
   ): Promise<T> {
     const cached = await this.get<T>(key);
-    
+
     if (cached !== null) {
       return cached;
     }
 
     const freshValue = await fallback();
     await this.set(key, freshValue, ttl);
-    
+
     return freshValue;
   }
 
@@ -126,15 +120,20 @@ export class CacheService implements OnModuleInit {
       // Note: This requires Redis-specific implementation
       // For now, we'll use a simplified approach
       const keys = await this.getKeysByPattern(pattern);
-      
+
       for (const key of keys) {
         await this.del(key);
       }
 
-      this.logger.log(`Invalidated ${keys.length} keys matching pattern: ${pattern}`);
+      this.logger.log(
+        `Invalidated ${keys.length} keys matching pattern: ${pattern}`,
+      );
       return keys.length;
     } catch (error) {
-      this.logger.error(`Cache invalidation error for pattern ${pattern}:`, error);
+      this.logger.error(
+        `Cache invalidation error for pattern ${pattern}:`,
+        error,
+      );
       return 0;
     }
   }
@@ -164,16 +163,69 @@ export class CacheService implements OnModuleInit {
    */
   async clear(): Promise<void> {
     try {
-      const cache = this.cacheManager as any;
-      if (typeof cache.reset === 'function') {
-        await cache.reset();
-      } else if (typeof cache.clear === 'function') {
-        await cache.clear();
+      const wasCleared = await this.clearCacheBackend();
+
+      if (!wasCleared) {
+        this.logger.warn(
+          'Cache clear skipped: active cache backend does not expose reset() or clear().',
+        );
+        return;
       }
+
       this.logger.log('Cache cleared');
     } catch (error) {
       this.logger.error('Cache clear error:', error);
     }
+  }
+
+  /**
+   * Clears cache across different cache-manager backend shapes.
+   * Supports top-level cache manager methods, nested store methods,
+   * and multi-store backends.
+   */
+  private async clearCacheBackend(): Promise<boolean> {
+    const cache = this.cacheManager as {
+      store?: unknown;
+      stores?: unknown[];
+    };
+
+    const targets: unknown[] = [cache, cache.store];
+
+    if (Array.isArray(cache.stores)) {
+      targets.push(...cache.stores);
+    }
+
+    let cleared = false;
+
+    for (const target of targets) {
+      if (!target) {
+        continue;
+      }
+
+      const didClear = await this.callResetOrClear(target);
+      cleared = cleared || didClear;
+    }
+
+    return cleared;
+  }
+
+  private async callResetOrClear(target: unknown): Promise<boolean> {
+    const candidate = target as {
+      reset?: () => Promise<void> | void;
+      clear?: () => Promise<void> | void;
+    };
+
+    if (typeof candidate.reset === 'function') {
+      await candidate.reset();
+      return true;
+    }
+
+    if (typeof candidate.clear === 'function') {
+      await candidate.clear();
+      return true;
+    }
+
+    return false;
   }
 
   /**

--- a/backend/src/database/database.module.ts
+++ b/backend/src/database/database.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { RedisService } from './redis.service';
+
+@Global()
+@Module({
+  providers: [RedisService],
+  exports: [RedisService],
+})
+export class DatabaseModule {}

--- a/backend/src/database/redis.service.ts
+++ b/backend/src/database/redis.service.ts
@@ -1,0 +1,139 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis from 'ioredis';
+
+@Injectable()
+export class RedisService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(RedisService.name);
+  private client: Redis | null = null;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.initializeClient();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (!this.client) {
+      return;
+    }
+
+    await this.client.quit();
+    this.client = null;
+  }
+
+  async getCache(key: string): Promise<string | null> {
+    const redis = await this.getClient();
+    if (!redis) {
+      return null;
+    }
+
+    return redis.get(key);
+  }
+
+  async setCache(
+    key: string,
+    value: string,
+    ttlSeconds?: number,
+  ): Promise<void> {
+    const redis = await this.getClient();
+    if (!redis) {
+      return;
+    }
+
+    if (ttlSeconds && ttlSeconds > 0) {
+      await redis.set(key, value, 'EX', ttlSeconds);
+      return;
+    }
+
+    await redis.set(key, value);
+  }
+
+  async deleteCache(key: string): Promise<void> {
+    const redis = await this.getClient();
+    if (!redis) {
+      return;
+    }
+
+    await redis.del(key);
+  }
+
+  // Backward-compatible aliases used by existing internal callers.
+  async get(key: string): Promise<string | null> {
+    return this.getCache(key);
+  }
+
+  async set(
+    key: string,
+    value: string,
+    modeOrTtl?: 'EX' | number,
+    duration?: number,
+  ): Promise<void> {
+    if (modeOrTtl === 'EX') {
+      await this.setCache(key, value, duration);
+      return;
+    }
+
+    await this.setCache(
+      key,
+      value,
+      typeof modeOrTtl === 'number' ? modeOrTtl : undefined,
+    );
+  }
+
+  async del(key: string): Promise<void> {
+    await this.deleteCache(key);
+  }
+
+  private async getClient(): Promise<Redis | null> {
+    if (this.client?.status === 'ready') {
+      return this.client;
+    }
+
+    return this.initializeClient();
+  }
+
+  private async initializeClient(): Promise<Redis | null> {
+    if (this.client && this.client.status !== 'end') {
+      if (this.client.status !== 'ready') {
+        try {
+          await this.client.connect();
+        } catch (error) {
+          this.logger.error('Redis reconnection failed', error as Error);
+          return null;
+        }
+      }
+
+      return this.client;
+    }
+
+    const host = this.configService.get<string>('redis.host', 'localhost');
+    const port = this.configService.get<number>('redis.port', 6379);
+
+    this.client = new Redis({
+      host,
+      port,
+      lazyConnect: true,
+      maxRetriesPerRequest: 2,
+    });
+
+    this.client.on('error', (error) => {
+      this.logger.error('Redis client error', error);
+    });
+
+    try {
+      await this.client.connect();
+      this.logger.log(`Redis connected at ${host}:${port}`);
+      return this.client;
+    } catch (error) {
+      this.logger.warn('Redis unavailable; cache operations will be skipped.');
+      this.logger.error('Redis connection failed', error as Error);
+      return null;
+    }
+  }
+}

--- a/backend/src/free-bet-vouchers/dto/create-free-bet-voucher.dto.ts
+++ b/backend/src/free-bet-vouchers/dto/create-free-bet-voucher.dto.ts
@@ -6,6 +6,8 @@ import {
   IsOptional,
   IsInt,
   Min,
+  IsIn,
+  IsString,
 } from 'class-validator';
 
 export class CreateFreeBetVoucherDto {
@@ -26,4 +28,13 @@ export class CreateFreeBetVoucherDto {
   @IsInt()
   @Min(1)
   maxActiveVouchersPerUser?: number;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['MANUAL', 'SPIN', 'PROMOTION', 'COMPENSATION'])
+  sourceType?: 'MANUAL' | 'SPIN' | 'PROMOTION' | 'COMPENSATION';
+
+  @IsOptional()
+  @IsString()
+  sourceReferenceId?: string;
 }

--- a/backend/src/free-bet-vouchers/entities/free-bet-voucher.entity.ts
+++ b/backend/src/free-bet-vouchers/entities/free-bet-voucher.entity.ts
@@ -3,7 +3,8 @@ import { BaseEntity } from '../../common/entities/base.entity';
 import { User } from '../../users/entities/user.entity';
 
 /**
- * Free bet vouchers from spin rewards.
+ * Free bet vouchers.
+ * - Can be issued independently (manual, promotion, spin, compensation).
  * - Cannot be withdrawn (not added to wallet balance).
  * - Can only be applied to betting.
  * - Automatically consumed on use.

--- a/backend/src/free-bet-vouchers/free-bet-vouchers.controller.ts
+++ b/backend/src/free-bet-vouchers/free-bet-vouchers.controller.ts
@@ -35,7 +35,7 @@ export class FreeBetVouchersController {
   constructor(private readonly freeBetVoucherService: FreeBetVoucherService) {}
 
   /**
-   * Create a free bet voucher (admin). Used e.g. for spin rewards.
+   * Create a free bet voucher (admin).
    * POST /free-bet-vouchers
    */
   @Post()

--- a/backend/src/free-bet-vouchers/free-bet-vouchers.service.spec.ts
+++ b/backend/src/free-bet-vouchers/free-bet-vouchers.service.spec.ts
@@ -1,0 +1,99 @@
+import { BadRequestException } from '@nestjs/common';
+import { FreeBetVoucherService } from './free-bet-vouchers.service';
+import { FreeBetVoucher } from './entities/free-bet-voucher.entity';
+
+describe('FreeBetVoucherService', () => {
+  const createService = () => {
+    const voucherRepository = {
+      findOne: jest.fn(),
+      createQueryBuilder: jest.fn(),
+      save: jest.fn(),
+      find: jest.fn(),
+      softRemove: jest.fn(),
+    };
+
+    const dataSource = {
+      manager: {},
+      createQueryRunner: jest.fn(),
+    };
+
+    const service = new FreeBetVoucherService(
+      voucherRepository as any,
+      dataSource as any,
+    );
+
+    return { service, voucherRepository, dataSource };
+  };
+
+  it('creates standalone voucher without spin reference', async () => {
+    const { service } = createService();
+
+    const save = jest.fn(async (voucher) => voucher);
+    const create = jest.fn((voucher) => voucher);
+
+    const manager = {
+      findOne: jest.fn().mockResolvedValue({ id: 'user-1' }),
+      getRepository: jest.fn().mockReturnValue({
+        create,
+        save,
+      }),
+    };
+
+    const result = await service.createVoucherWithManager(manager as any, {
+      userId: 'user-1',
+      amount: 20,
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    expect(manager.getRepository).toHaveBeenCalled();
+    expect(result.metadata.sourceType).toBe('MANUAL');
+    expect(result.metadata.sourceReferenceId).toBeUndefined();
+    expect(result.metadata.usageCount).toBe(0);
+  });
+
+  it('tracks voucher usage metadata on consume', async () => {
+    const { service } = createService();
+
+    const voucher: Partial<FreeBetVoucher> = {
+      id: 'voucher-1',
+      userId: 'user-1',
+      expiresAt: new Date(Date.now() + 60_000),
+      used: false,
+      metadata: {},
+    };
+
+    const manager = {
+      findOne: jest.fn().mockResolvedValue(voucher),
+      save: jest.fn(async (value) => value),
+    };
+
+    const result = await service.consumeVoucherWithManager(
+      manager as any,
+      'voucher-1',
+      'user-1',
+      'bet-1',
+    );
+
+    expect(result.used).toBe(true);
+    expect(result.usedForBetId).toBe('bet-1');
+    expect(result.metadata.usageCount).toBe(1);
+    expect(result.metadata.lastUsedForBetId).toBe('bet-1');
+    expect(Array.isArray(result.metadata.usageHistory)).toBe(true);
+    expect(result.metadata.usageHistory).toHaveLength(1);
+  });
+
+  it('rejects expired voucher during validation', async () => {
+    const { service, voucherRepository } = createService();
+
+    voucherRepository.findOne.mockResolvedValue({
+      id: 'voucher-1',
+      userId: 'user-1',
+      expiresAt: new Date(Date.now() - 1_000),
+      used: false,
+    });
+
+    await expect(service.validateVoucher('voucher-1', 'user-1')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+});

--- a/backend/src/free-bet-vouchers/free-bet-vouchers.service.ts
+++ b/backend/src/free-bet-vouchers/free-bet-vouchers.service.ts
@@ -29,8 +29,8 @@ export class FreeBetVoucherService {
   ) {}
 
   /**
-   * Create a free bet voucher for a user (e.g. from spin rewards).
-   * Vouchers are non-withdrawable and can only be applied to betting.
+   * Create a free bet voucher for a user.
+   * Works independently of spin and can carry optional source metadata.
    */
   async createVoucher(
     createVoucherDto: CreateFreeBetVoucherDto,
@@ -83,7 +83,11 @@ export class FreeBetVoucherService {
       used: false,
       metadata: {
         ...(createVoucherDto.metadata ?? {}),
+        sourceType: createVoucherDto.sourceType ?? 'MANUAL',
+        sourceReferenceId: createVoucherDto.sourceReferenceId,
         maxActiveVouchersPerUser: createVoucherDto.maxActiveVouchersPerUser,
+        usageCount: 0,
+        usageHistory: [],
       },
     });
     return voucherRepo.save(voucher);
@@ -98,6 +102,8 @@ export class FreeBetVoucherService {
     limit = 10,
     includeUsed = false,
   ): Promise<PaginatedVouchers> {
+    await this.markExpiredVouchersForUser(userId);
+
     const skip = (page - 1) * limit;
     const now = new Date();
 
@@ -152,6 +158,8 @@ export class FreeBetVoucherService {
    * Used when placing a bet to choose a voucher.
    */
   async getAvailableVouchers(userId: string): Promise<FreeBetVoucher[]> {
+    await this.markExpiredVouchersForUser(userId);
+
     const now = new Date();
     return this.voucherRepository
       .createQueryBuilder('v')
@@ -177,15 +185,9 @@ export class FreeBetVoucherService {
     if (!voucher) {
       throw new NotFoundException('Free bet voucher not found');
     }
-    if (voucher.userId !== userId) {
-      throw new ForbiddenException('You do not have access to this voucher');
-    }
-    if (voucher.used) {
-      throw new ConflictException('Voucher has already been used');
-    }
-    if (new Date() > voucher.expiresAt) {
-      throw new BadRequestException('Voucher has expired');
-    }
+
+    this.assertVoucherUsable(voucher, userId);
+
     return voucher;
   }
 
@@ -276,19 +278,17 @@ export class FreeBetVoucherService {
       if (!voucher) {
         throw new NotFoundException('Free bet voucher not found');
       }
-      if (voucher.userId !== userId) {
-        throw new ForbiddenException('You do not have access to this voucher');
-      }
-      if (voucher.used) {
-        throw new ConflictException('Voucher has already been used');
-      }
-      if (new Date() > voucher.expiresAt) {
-        throw new BadRequestException('Voucher has expired');
-      }
 
+      this.assertVoucherUsable(voucher, userId);
+
+      const usedAt = new Date();
       voucher.used = true;
-      voucher.usedAt = new Date();
+      voucher.usedAt = usedAt;
       voucher.usedForBetId = betId;
+      voucher.metadata = this.withUsageTracking(voucher.metadata, {
+        usedAt,
+        betId,
+      });
       const saved = await qr.manager.save(voucher);
       await qr.commitTransaction();
       return saved;
@@ -314,19 +314,17 @@ export class FreeBetVoucherService {
     if (!voucher) {
       throw new NotFoundException('Free bet voucher not found');
     }
-    if (voucher.userId !== userId) {
-      throw new ForbiddenException('You do not have access to this voucher');
-    }
-    if (voucher.used) {
-      throw new ConflictException('Voucher has already been used');
-    }
-    if (new Date() > voucher.expiresAt) {
-      throw new BadRequestException('Voucher has expired');
-    }
 
+    this.assertVoucherUsable(voucher, userId);
+
+    const usedAt = new Date();
     voucher.used = true;
-    voucher.usedAt = new Date();
+    voucher.usedAt = usedAt;
     voucher.usedForBetId = betId;
+    voucher.metadata = this.withUsageTracking(voucher.metadata, {
+      usedAt,
+      betId,
+    });
     return manager.save(voucher);
   }
 
@@ -379,10 +377,18 @@ export class FreeBetVoucherService {
         'Voucher is linked to a different bet and cannot be restored',
       );
     }
+    if (this.isVoucherExpired(voucher)) {
+      throw new BadRequestException('Voucher has expired and cannot be restored');
+    }
 
     voucher.used = false;
     voucher.usedAt = undefined;
     voucher.usedForBetId = undefined;
+    voucher.metadata = {
+      ...(voucher.metadata ?? {}),
+      restoreCount: Number(voucher.metadata?.restoreCount ?? 0) + 1,
+      lastRestoredAt: new Date().toISOString(),
+    };
     return manager.save(voucher);
   }
 
@@ -397,8 +403,9 @@ export class FreeBetVoucherService {
     totalValue: number;
     activeValue: number;
   }> {
+    await this.markExpiredVouchersForUser(userId);
+
     const list = await this.voucherRepository.find({ where: { userId } });
-    const now = new Date();
     const stats = {
       totalVouchers: list.length,
       activeVouchers: 0,
@@ -413,7 +420,7 @@ export class FreeBetVoucherService {
       stats.totalValue += amt;
       if (v.used) {
         stats.usedVouchers++;
-      } else if (new Date(v.expiresAt) < now) {
+      } else if (this.isVoucherExpired(v)) {
         stats.expiredVouchers++;
       } else {
         stats.activeVouchers++;
@@ -421,5 +428,72 @@ export class FreeBetVoucherService {
       }
     }
     return stats;
+  }
+
+  private assertVoucherUsable(voucher: FreeBetVoucher, userId: string): void {
+    if (voucher.userId !== userId) {
+      throw new ForbiddenException('You do not have access to this voucher');
+    }
+    if (voucher.used) {
+      throw new ConflictException('Voucher has already been used');
+    }
+    if (this.isVoucherExpired(voucher)) {
+      throw new BadRequestException('Voucher has expired');
+    }
+  }
+
+  private isVoucherExpired(voucher: FreeBetVoucher): boolean {
+    return new Date() > new Date(voucher.expiresAt);
+  }
+
+  private withUsageTracking(
+    metadata: Record<string, any> | undefined,
+    usage: { usedAt: Date; betId: string },
+  ): Record<string, any> {
+    const current = metadata ?? {};
+    const currentHistory = Array.isArray(current.usageHistory)
+      ? current.usageHistory
+      : [];
+
+    return {
+      ...current,
+      usageCount: Number(current.usageCount ?? 0) + 1,
+      lastUsedAt: usage.usedAt.toISOString(),
+      lastUsedForBetId: usage.betId,
+      usageHistory: [
+        ...currentHistory,
+        {
+          usedAt: usage.usedAt.toISOString(),
+          betId: usage.betId,
+        },
+      ].slice(-20),
+    };
+  }
+
+  private async markExpiredVouchersForUser(userId: string): Promise<void> {
+    const now = new Date();
+    const vouchers = await this.voucherRepository
+      .createQueryBuilder('v')
+      .where('v.userId = :userId', { userId })
+      .andWhere('v.used = :used', { used: false })
+      .andWhere('v.expiresAt <= :now', { now })
+      .getMany();
+
+    if (vouchers.length === 0) {
+      return;
+    }
+
+    for (const voucher of vouchers) {
+      voucher.metadata = {
+        ...(voucher.metadata ?? {}),
+        status: 'EXPIRED',
+        expiredAt:
+          typeof voucher.metadata?.expiredAt === 'string'
+            ? voucher.metadata.expiredAt
+            : now.toISOString(),
+      };
+    }
+
+    await this.voucherRepository.save(vouchers);
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "ethers": "^6.16.0",
     "@nestjs/cqrs": "^11.0.3",
     "@nestjs/typeorm": "^11.0.0",
+    "ioredis": "^5.10.1",
     "nest-winston": "^1.10.2",
     "typeorm": "^0.3.28",
     "uuid": "^13.0.0",


### PR DESCRIPTION
## Summary
This PR implements three enhancements to the cache layer, adds a dedicated Redis service, and improves the free-bet-vouchers module with standalone voucher support and comprehensive usage tracking.

## Closes
- Closes #307
- Closes #306
- Closes #308

## Changes

### Cache Service Backend Compatibility (#307)
- Enhanced `cache.reset()` to work with all cache-manager backends (top-level, nested store, multi-store arrays)
- Added `clearCacheBackend()` method with multi-target support
- Added `callResetOrClear()` for backend method detection
- Added comprehensive unit tests covering all backend variants
- All existing cache operations remain unchanged (backward compatible)

### Redis Caching Service
- Created `src/database/redis.service.ts` with dedicated Redis integration
- Implemented `getCache()`, `setCache()`, `deleteCache()` methods
- Added backward-compatible aliases (`get()`, `set()`, `del()`) for existing callers
- Created global `DatabaseModule` for seamless DI across the application
- Added ioredis v5.10.1 to root `package.json`
- Integrated DatabaseModule into AppModule for application-wide access

### Free-Bet-Vouchers Module Enhancements (#306)
- Decoupled voucher creation from spin rewards (now support MANUAL, SPIN, PROMOTION, COMPENSATION sources)
- Added `sourceType` and `sourceReferenceId` fields to CreateFreeBetVoucherDto
- Implemented usage tracking with:
  - `usageCount` tracking number of times voucher is consumed
  - `usageHistory` array (capped to 20 entries) tracking each usage event
  - `lastUsedAt` and `lastUsedForBetId` timestamps
- Added restore tracking with `restoreCount` and `lastRestoredAt`
- Centralized expiry handling via `isVoucherExpired()` and `assertVoucherUsable()`
- Implemented `markExpiredVouchersForUser()` to uniformly track expired state in metadata
- Full backward compatibility with existing spin reward integration
- Added unit tests for standalone creation, usage tracking, and expiry validation

## Testing
- All 12 tests passing (cache service + free-bet-vouchers modules)
- No TypeScript compilation errors
- No regression in existing cache-invalidation tests
- Backward compatible with existing integrations (spin service, ai-prediction-service)

## Files Changed
- `backend/src/app.module.ts` - Integrated DatabaseModule
- `backend/src/common/cache/cache.service.ts` - Backend-agnostic reset
- `backend/src/common/cache/cache.service.spec.ts` - Cache backend tests (NEW)
- `backend/src/database/redis.service.ts` - Redis service (NEW)
- `backend/src/database/database.module.ts` - Global DI module (NEW)
- `backend/src/free-bet-vouchers/dto/create-free-bet-voucher.dto.ts` - Added source fields
- `backend/src/free-bet-vouchers/entities/free-bet-voucher.entity.ts` - Updated documentation
- `backend/src/free-bet-vouchers/free-bet-vouchers.controller.ts` - Updated endpoint doc
- `backend/src/free-bet-vouchers/free-bet-vouchers.service.ts` - Full enhancement
- `backend/src/free-bet-vouchers/free-bet-vouchers.service.spec.ts` - Usage tracking tests (NEW)
- `package.json` - Added ioredis dependency