### PR TITLE
feat: staking tiers, delegation, auto-compound & H2H comparison

### DIFF
--- a/backend/src/leaderboard/controllers/ranking.controller.ts
+++ b/backend/src/leaderboard/controllers/ranking.controller.ts
@@ -14,7 +14,7 @@ import {
 } from '@nestjs/swagger';
 import { HttpCacheInterceptor } from '../../common/cache/interceptors/http-cache.interceptor';
 import { CacheKey } from '../../common/cache/decorators/cache-key.decorator';
-import { RankingService, PaginatedRanking, UserRanking } from '../services/ranking.service';
+import { RankingService, PaginatedRanking, UserRanking, H2HComparison } from '../services/ranking.service';
 import { RankingQueryDto, TimeFrame, RankingType } from '../dto/ranking-query.dto';
 
 @ApiTags('Rankings')
@@ -259,8 +259,7 @@ export class RankingController {
   })
   async getRankingsSummary(
     @Query('timeFrame') timeFrame: TimeFrame = TimeFrame.ALL_TIME,
-  ): Promise<any> {
-    const [earners, stakers, predictors] = await Promise.all([
+  ): Promise<any> {    const [earners, stakers, predictors] = await Promise.all([
       this.rankingService.getHighestEarners({ page: 1, limit: 10, timeFrame }),
       this.rankingService.getBiggestStakers({ page: 1, limit: 10, timeFrame }),
       this.rankingService.getBestPredictors({ page: 1, limit: 10, timeFrame }),
@@ -300,5 +299,17 @@ export class RankingController {
       timeFrame,
       lastUpdated: new Date(),
     };
+  }
+
+  @Get('h2h/:userAId/:userBId')
+  @ApiOperation({ summary: 'Head-to-head comparison between two users' })
+  @ApiParam({ name: 'userAId', description: 'First user UUID' })
+  @ApiParam({ name: 'userBId', description: 'Second user UUID' })
+  @ApiResponse({ status: 200, description: 'H2H comparison result' })
+  async getH2H(
+    @Param('userAId') userAId: string,
+    @Param('userBId') userBId: string,
+  ): Promise<H2HComparison> {
+    return this.rankingService.getH2HComparison(userAId, userBId);
   }
 }

--- a/backend/src/leaderboard/services/ranking.service.ts
+++ b/backend/src/leaderboard/services/ranking.service.ts
@@ -74,6 +74,30 @@ export interface BestPredictor {
   lastBetAt: Date;
 }
 
+export interface H2HComparison {
+  userA: {
+    userId: string;
+    username: string;
+    winRate: number;
+    totalProfit: number;
+    avgOdds: number;
+    currentStreak: number;
+    highestStreak: number;
+    totalBets: number;
+  };
+  userB: {
+    userId: string;
+    username: string;
+    winRate: number;
+    totalProfit: number;
+    avgOdds: number;
+    currentStreak: number;
+    highestStreak: number;
+    totalBets: number;
+  };
+  winner: string | null; // userId of overall winner or null if tied
+}
+
 @Injectable()
 export class RankingService {
   private readonly logger = new Logger(RankingService.name);
@@ -438,5 +462,38 @@ export class RankingService {
     }
 
     this.logger.log('Ranking cache invalidated');
+  }
+
+  async getH2HComparison(userAId: string, userBId: string): Promise<H2HComparison> {
+    const [a, b] = await Promise.all([
+      this.leaderboardRepository.findOne({ where: { userId: userAId }, relations: ['user'] }),
+      this.leaderboardRepository.findOne({ where: { userId: userBId }, relations: ['user'] }),
+    ]);
+
+    if (!a || !b) throw new Error('One or both users not found in leaderboard');
+
+    const toStats = (entry: Leaderboard, user: any) => ({
+      userId: entry.userId,
+      username: user?.username ?? entry.userId,
+      winRate: entry.totalBets > 0 ? Number(((entry.betsWon / entry.totalBets) * 100).toFixed(2)) : 0,
+      totalProfit: Number(entry.totalWinnings),
+      avgOdds: entry.totalBets > 0 ? Number((Number(entry.totalWinnings) / entry.totalBets).toFixed(4)) : 0,
+      currentStreak: entry.winningStreak,
+      highestStreak: entry.highestWinningStreak,
+      totalBets: entry.totalBets,
+    });
+
+    const statsA = toStats(a, a.user);
+    const statsB = toStats(b, b.user);
+
+    // Determine winner by score: winRate (40%) + profit (40%) + streak (20%)
+    const scoreA = statsA.winRate * 0.4 + statsA.totalProfit * 0.4 + statsA.highestStreak * 0.2;
+    const scoreB = statsB.winRate * 0.4 + statsB.totalProfit * 0.4 + statsB.highestStreak * 0.2;
+
+    return {
+      userA: statsA,
+      userB: statsB,
+      winner: scoreA > scoreB ? userAId : scoreB > scoreA ? userBId : null,
+    };
   }
 }

--- a/backend/src/migrations/1745500000000-StakingFeatures.ts
+++ b/backend/src/migrations/1745500000000-StakingFeatures.ts
@@ -1,0 +1,59 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class StakingFeatures1745500000000 implements MigrationInterface {
+  name = 'StakingFeatures1745500000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    // #357: staking_tiers table
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "staking_tiers" (
+        "id"                   uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "lockDays"             integer NOT NULL,
+        "apr"                  numeric(5,4) NOT NULL,
+        "earlyUnstakePenalty"  numeric(5,4) NOT NULL DEFAULT 0.05,
+        "active"               boolean NOT NULL DEFAULT true,
+        CONSTRAINT "PK_staking_tiers" PRIMARY KEY ("id")
+      )
+    `);
+
+    // Seed default tiers
+    await queryRunner.query(`
+      INSERT INTO "staking_tiers" ("lockDays", "apr", "earlyUnstakePenalty") VALUES
+        (30,  0.12, 0.05),
+        (90,  0.15, 0.08),
+        (180, 0.20, 0.10),
+        (365, 0.25, 0.15)
+      ON CONFLICT DO NOTHING
+    `);
+
+    // #356: stake_delegations table
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "stake_delegations" (
+        "id"            uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "delegatorId"   uuid NOT NULL,
+        "delegateeId"   uuid NOT NULL,
+        "amount"        numeric(18,6) NOT NULL,
+        "active"        boolean NOT NULL DEFAULT true,
+        "earnedRewards" numeric(18,6) NOT NULL DEFAULT 0,
+        "createdAt"     TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt"     TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_stake_delegations" PRIMARY KEY ("id")
+      )
+    `);
+
+    // #357 + #358: new columns on stakes
+    await queryRunner.query(`ALTER TABLE "stakes" ADD COLUMN IF NOT EXISTS "lockDays"    integer NOT NULL DEFAULT 0`);
+    await queryRunner.query(`ALTER TABLE "stakes" ADD COLUMN IF NOT EXISTS "lockedUntil" TIMESTAMP`);
+    await queryRunner.query(`ALTER TABLE "stakes" ADD COLUMN IF NOT EXISTS "apr"         numeric(5,4) NOT NULL DEFAULT 0.12`);
+    await queryRunner.query(`ALTER TABLE "stakes" ADD COLUMN IF NOT EXISTS "autoCompound" boolean NOT NULL DEFAULT false`);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "stakes" DROP COLUMN IF EXISTS "autoCompound"`);
+    await queryRunner.query(`ALTER TABLE "stakes" DROP COLUMN IF EXISTS "apr"`);
+    await queryRunner.query(`ALTER TABLE "stakes" DROP COLUMN IF EXISTS "lockedUntil"`);
+    await queryRunner.query(`ALTER TABLE "stakes" DROP COLUMN IF EXISTS "lockDays"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "stake_delegations"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "staking_tiers"`);
+  }
+}

--- a/backend/src/stake/entities/stake-delegation.entity.ts
+++ b/backend/src/stake/entities/stake-delegation.entity.ts
@@ -1,0 +1,32 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+/** Delegator earns 1% of delegatee's staking rewards */
+@Entity('stake_delegations')
+export class StakeDelegation {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  /** The user who delegates their stake */
+  @Column('uuid')
+  delegatorId!: string;
+
+  /** The respected bettor receiving the delegated stake */
+  @Column('uuid')
+  delegateeId!: string;
+
+  @Column('decimal', { precision: 18, scale: 6 })
+  amount!: number;
+
+  @Column({ default: true })
+  active!: boolean;
+
+  /** Cumulative rewards earned by delegator (1% of delegatee rewards) */
+  @Column('decimal', { precision: 18, scale: 6, default: 0 })
+  earnedRewards!: number;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/backend/src/stake/entities/stake.entity.ts
+++ b/backend/src/stake/entities/stake.entity.ts
@@ -29,6 +29,22 @@ export class Stake {
   @Column({ nullable: true })
   unstakedAt!: Date;
 
+  /** #357: Tier lock-up in days (0 = no lock) */
+  @Column('int', { default: 0 })
+  lockDays!: number;
+
+  /** #357: Timestamp when lock expires */
+  @Column({ nullable: true })
+  lockedUntil!: Date;
+
+  /** #357: APR applied to this stake (e.g. 0.12) */
+  @Column('decimal', { precision: 5, scale: 4, default: 0.12 })
+  apr!: number;
+
+  /** #358: Auto-compound pending rewards instead of paying out */
+  @Column({ default: false })
+  autoCompound!: boolean;
+
   @CreateDateColumn()
   stakedAt!: Date;
 

--- a/backend/src/stake/entities/staking-tier.entity.ts
+++ b/backend/src/stake/entities/staking-tier.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('staking_tiers')
+export class StakingTier {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  /** Lock-up duration in days */
+  @Column('int')
+  lockDays!: number;
+
+  /** Annual Percentage Rate e.g. 0.12 = 12% */
+  @Column('decimal', { precision: 5, scale: 4 })
+  apr!: number;
+
+  /** Early unstake penalty as a fraction of principal e.g. 0.05 = 5% */
+  @Column('decimal', { precision: 5, scale: 4, default: 0.05 })
+  earlyUnstakePenalty!: number;
+
+  @Column({ default: true })
+  active!: boolean;
+}

--- a/backend/src/stake/staking.controller.ts
+++ b/backend/src/stake/staking.controller.ts
@@ -1,13 +1,37 @@
-import { Controller, Post, Get, Body, Param } from '@nestjs/common';
+import { Controller, Post, Get, Body, Param, Patch } from '@nestjs/common';
 import { StakingService } from './staking.service';
 
 @Controller('staking')
 export class StakingController {
   constructor(private readonly stakingService: StakingService) {}
 
+  // ─── Tiers (#357) ─────────────────────────────────────────────────────────
+
+  @Get('tiers')
+  getTiers() {
+    return this.stakingService.getTiers();
+  }
+
+  // ─── Core staking ─────────────────────────────────────────────────────────
+
   @Post('stake')
-  stake(@Body() body: { playerId: string; amount: number; stellarTxHash?: string }) {
-    return this.stakingService.stake(body.playerId, body.amount, body.stellarTxHash);
+  stake(
+    @Body()
+    body: {
+      playerId: string;
+      amount: number;
+      stellarTxHash?: string;
+      lockDays?: number;   // #357
+      autoCompound?: boolean; // #358
+    },
+  ) {
+    return this.stakingService.stake(
+      body.playerId,
+      body.amount,
+      body.stellarTxHash,
+      body.lockDays ?? 0,
+      body.autoCompound ?? false,
+    );
   }
 
   @Post(':stakeId/unstake')
@@ -25,8 +49,37 @@ export class StakingController {
     return this.stakingService.compoundRewards(body.playerId, stakeId);
   }
 
+  /** #358: Toggle auto-compound per stake */
+  @Patch(':stakeId/auto-compound')
+  setAutoCompound(
+    @Param('stakeId') stakeId: string,
+    @Body() body: { playerId: string; autoCompound: boolean },
+  ) {
+    return this.stakingService.setAutoCompound(body.playerId, stakeId, body.autoCompound);
+  }
+
   @Get(':playerId')
   getStakes(@Param('playerId') playerId: string) {
     return this.stakingService.getPlayerStakes(playerId);
+  }
+
+  // ─── Delegation (#356) ────────────────────────────────────────────────────
+
+  @Post('delegate')
+  delegate(@Body() body: { delegatorId: string; delegateeId: string; amount: number }) {
+    return this.stakingService.delegate(body.delegatorId, body.delegateeId, body.amount);
+  }
+
+  @Post('delegate/:delegationId/undelegate')
+  undelegate(
+    @Param('delegationId') delegationId: string,
+    @Body() body: { delegatorId: string },
+  ) {
+    return this.stakingService.undelegate(body.delegatorId, delegationId);
+  }
+
+  @Get('delegate/:playerId')
+  getDelegations(@Param('playerId') playerId: string) {
+    return this.stakingService.getDelegations(playerId);
   }
 }

--- a/backend/src/stake/staking.module.ts
+++ b/backend/src/stake/staking.module.ts
@@ -5,10 +5,17 @@ import { StakingService } from './staking.service';
 import { StakingController } from './staking.controller';
 import { WalletModule } from '../wallet/wallet.module';
 import { Stake } from './entities/stake.entity';
+import { StakeDelegation } from './entities/stake-delegation.entity';
+import { StakingTier } from './entities/staking-tier.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Stake]), ScheduleModule.forRoot(), WalletModule],
+  imports: [
+    TypeOrmModule.forFeature([Stake, StakeDelegation, StakingTier]),
+    ScheduleModule.forRoot(),
+    WalletModule,
+  ],
   providers: [StakingService],
   controllers: [StakingController],
+  exports: [StakingService],
 })
 export class StakingModule {}

--- a/backend/src/stake/staking.service.ts
+++ b/backend/src/stake/staking.service.ts
@@ -3,24 +3,70 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { Stake } from './entities/stake.entity';
+import { StakeDelegation } from './entities/stake-delegation.entity';
+import { StakingTier } from './entities/staking-tier.entity';
 import { WalletService } from '../wallet/services/wallet.service';
 
-// Annual Percentage Rate — adjust as needed
-const APR = 0.12;
-// How often rewards are calculated (hourly)
-const REWARD_INTERVAL_HOURS = 1;
+/** Default tiers seeded on first use */
+const DEFAULT_TIERS: Pick<StakingTier, 'lockDays' | 'apr' | 'earlyUnstakePenalty'>[] = [
+  { lockDays: 30,  apr: 0.12, earlyUnstakePenalty: 0.05 },
+  { lockDays: 90,  apr: 0.15, earlyUnstakePenalty: 0.08 },
+  { lockDays: 180, apr: 0.20, earlyUnstakePenalty: 0.10 },
+  { lockDays: 365, apr: 0.25, earlyUnstakePenalty: 0.15 },
+];
+
+const DELEGATION_CUT = 0.01; // 1% of delegatee rewards go to delegator
 
 @Injectable()
 export class StakingService {
   constructor(
     @InjectRepository(Stake)
     private stakeRepo: Repository<Stake>,
+    @InjectRepository(StakeDelegation)
+    private delegationRepo: Repository<StakeDelegation>,
+    @InjectRepository(StakingTier)
+    private tierRepo: Repository<StakingTier>,
     private walletService: WalletService,
     private dataSource: DataSource,
   ) {}
 
-  async stake(playerId: string, amount: number, stellarTxHash?: string): Promise<Stake> {
+  // ─── #357 Tier helpers ────────────────────────────────────────────────────
+
+  async getTiers(): Promise<StakingTier[]> {
+    const tiers = await this.tierRepo.find({ where: { active: true }, order: { lockDays: 'ASC' } });
+    if (tiers.length) return tiers;
+    // Seed defaults on first call
+    const seeded = this.tierRepo.create(DEFAULT_TIERS.map(t => ({ ...t, active: true })));
+    return this.tierRepo.save(seeded);
+  }
+
+  private async getTierByLockDays(lockDays: number): Promise<StakingTier | null> {
+    return this.tierRepo.findOne({ where: { lockDays, active: true } });
+  }
+
+  // ─── Core staking ─────────────────────────────────────────────────────────
+
+  /**
+   * Stake with optional tier (lockDays) and auto-compound flag (#357, #358)
+   */
+  async stake(
+    playerId: string,
+    amount: number,
+    stellarTxHash?: string,
+    lockDays = 0,
+    autoCompound = false,
+  ): Promise<Stake> {
     if (amount <= 0) throw new BadRequestException('Stake amount must be positive');
+
+    let apr = 0.12;
+    let lockedUntil: Date | undefined;
+
+    if (lockDays > 0) {
+      const tier = await this.getTierByLockDays(lockDays);
+      if (!tier) throw new BadRequestException(`No tier found for ${lockDays} lock days`);
+      apr = Number(tier.apr);
+      lockedUntil = new Date(Date.now() + lockDays * 24 * 60 * 60 * 1000);
+    }
 
     const queryRunner = this.dataSource.createQueryRunner();
     await queryRunner.connect();
@@ -28,8 +74,9 @@ export class StakingService {
 
     try {
       await this.walletService.debit(playerId, amount, 'STAKE');
-
-      const s = queryRunner.manager.create(Stake, { playerId, amount, stellarTxHash });
+      const s = queryRunner.manager.create(Stake, {
+        playerId, amount, stellarTxHash, lockDays, apr, lockedUntil, autoCompound,
+      });
       const saved = await queryRunner.manager.save(s);
       await queryRunner.commitTransaction();
       return saved;
@@ -41,6 +88,9 @@ export class StakingService {
     }
   }
 
+  /**
+   * Unstake with early-exit penalty if still within lock period (#357)
+   */
   async unstake(playerId: string, stakeId: string): Promise<Stake> {
     const s = await this.stakeRepo.findOne({ where: { id: stakeId, playerId, active: true } });
     if (!s) throw new NotFoundException('Active stake not found');
@@ -50,8 +100,19 @@ export class StakingService {
     await queryRunner.startTransaction();
 
     try {
-      // Return principal + any pending rewards
-      const total = parseFloat((s.amount + s.pendingRewards).toFixed(6));
+      let principal = s.amount;
+      let penaltyApplied = 0;
+
+      // Apply early unstake penalty if still locked
+      if (s.lockedUntil && new Date() < s.lockedUntil && s.lockDays > 0) {
+        const tier = await this.getTierByLockDays(s.lockDays);
+        if (tier) {
+          penaltyApplied = parseFloat((principal * Number(tier.earlyUnstakePenalty)).toFixed(6));
+          principal = parseFloat((principal - penaltyApplied).toFixed(6));
+        }
+      }
+
+      const total = parseFloat((principal + s.pendingRewards).toFixed(6));
       await this.walletService.credit(playerId, total, 'UNSTAKE');
 
       s.active = false;
@@ -93,29 +154,8 @@ export class StakingService {
     }
   }
 
-  // Auto-distribute rewards every hour
-  @Cron(CronExpression.EVERY_HOUR)
-  async distributeRewards(): Promise<void> {
-    const activeStakes = await this.stakeRepo.find({ where: { active: true } });
-    if (!activeStakes.length) return;
-
-    const hourlyRate = APR / (365 * 24);
-
-    for (const s of activeStakes) {
-      const reward = parseFloat((s.amount * hourlyRate).toFixed(6));
-      s.pendingRewards = parseFloat((s.pendingRewards + reward).toFixed(6));
-    }
-
-    await this.stakeRepo.save(activeStakes);
-  }
-
-  async getPlayerStakes(playerId: string): Promise<Stake[]> {
-    return this.stakeRepo.find({ where: { playerId }, order: { stakedAt: 'DESC' } });
-  }
-
   /**
-   * Compound rewards: add pending rewards to the stake principal.
-   * Tracks compounded amount separately on the stake record.
+   * Compound rewards: add pending rewards to principal (#358)
    */
   async compoundRewards(playerId: string, stakeId: string): Promise<Stake> {
     const s = await this.stakeRepo.findOne({ where: { id: stakeId, playerId, active: true } });
@@ -140,5 +180,124 @@ export class StakingService {
     } finally {
       await queryRunner.release();
     }
+  }
+
+  /**
+   * Toggle auto-compound flag on a stake (#358)
+   */
+  async setAutoCompound(playerId: string, stakeId: string, autoCompound: boolean): Promise<Stake> {
+    const s = await this.stakeRepo.findOne({ where: { id: stakeId, playerId, active: true } });
+    if (!s) throw new NotFoundException('Active stake not found');
+    s.autoCompound = autoCompound;
+    return this.stakeRepo.save(s);
+  }
+
+  // ─── #356 Delegation ──────────────────────────────────────────────────────
+
+  async delegate(delegatorId: string, delegateeId: string, amount: number): Promise<StakeDelegation> {
+    if (amount <= 0) throw new BadRequestException('Delegation amount must be positive');
+    if (delegatorId === delegateeId) throw new BadRequestException('Cannot delegate to yourself');
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      await this.walletService.debit(delegatorId, amount, 'STAKE');
+      const d = queryRunner.manager.create(StakeDelegation, { delegatorId, delegateeId, amount });
+      const saved = await queryRunner.manager.save(d);
+      await queryRunner.commitTransaction();
+      return saved;
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      throw err;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  async undelegate(delegatorId: string, delegationId: string): Promise<StakeDelegation> {
+    const d = await this.delegationRepo.findOne({ where: { id: delegationId, delegatorId, active: true } });
+    if (!d) throw new NotFoundException('Active delegation not found');
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      const total = parseFloat((d.amount + d.earnedRewards).toFixed(6));
+      await this.walletService.credit(delegatorId, total, 'UNSTAKE');
+      d.active = false;
+      const saved = await queryRunner.manager.save(d);
+      await queryRunner.commitTransaction();
+      return saved;
+    } catch (err) {
+      await queryRunner.rollbackTransaction();
+      throw err;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  async getDelegations(playerId: string): Promise<StakeDelegation[]> {
+    return this.delegationRepo.find({
+      where: [{ delegatorId: playerId }, { delegateeId: playerId }],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  // ─── Reward distribution ──────────────────────────────────────────────────
+
+  /** Distribute rewards every hour using per-stake APR; auto-compound if flagged (#357, #358) */
+  @Cron(CronExpression.EVERY_HOUR)
+  async distributeRewards(): Promise<void> {
+    const activeStakes = await this.stakeRepo.find({ where: { active: true } });
+    if (!activeStakes.length) return;
+
+    const toSave: Stake[] = [];
+
+    for (const s of activeStakes) {
+      const hourlyRate = Number(s.apr) / (365 * 24);
+      const reward = parseFloat((s.amount * hourlyRate).toFixed(6));
+
+      if (s.autoCompound) {
+        // #358: auto-compound — add directly to principal
+        s.amount = parseFloat((s.amount + reward).toFixed(6));
+        s.compoundedAmount = parseFloat(((s.compoundedAmount ?? 0) + reward).toFixed(6));
+      } else {
+        s.pendingRewards = parseFloat((s.pendingRewards + reward).toFixed(6));
+      }
+      toSave.push(s);
+    }
+
+    await this.stakeRepo.save(toSave);
+
+    // #356: credit 1% of each stake's reward to active delegators
+    const activeDelegations = await this.delegationRepo.find({ where: { active: true } });
+    if (!activeDelegations.length) return;
+
+    // Build a map of delegateeId -> total reward earned this cycle
+    const delegateeRewards = new Map<string, number>();
+    for (const s of activeStakes) {
+      const hourlyRate = Number(s.apr) / (365 * 24);
+      const reward = parseFloat((s.amount * hourlyRate).toFixed(6));
+      delegateeRewards.set(s.playerId, (delegateeRewards.get(s.playerId) ?? 0) + reward);
+    }
+
+    const delegationsToSave: StakeDelegation[] = [];
+    for (const d of activeDelegations) {
+      const delegateeTotal = delegateeRewards.get(d.delegateeId) ?? 0;
+      if (delegateeTotal > 0) {
+        const cut = parseFloat((delegateeTotal * DELEGATION_CUT).toFixed(6));
+        d.earnedRewards = parseFloat((d.earnedRewards + cut).toFixed(6));
+        delegationsToSave.push(d);
+      }
+    }
+
+    if (delegationsToSave.length) await this.delegationRepo.save(delegationsToSave);
+  }
+
+  async getPlayerStakes(playerId: string): Promise<Stake[]> {
+    return this.stakeRepo.find({ where: { playerId }, order: { stakedAt: 'DESC' } });
   }
 }


### PR DESCRIPTION
Closes #341, closes #356, closes #357, closes #358

## Changes
- **#341** `GET /rankings/h2h/:userAId/:userBId` — compare win rate, profit, avg odds, streaks
- **#356** Staking delegation: `POST /staking/delegate`, undelegate, list; delegator earns 1% of delegatee rewards hourly
- **#357** Staking tier system: `StakingTier` entity, tier-based APR (30d/12%, 90d/15%, 180d/20%, 365d/25%), early unstake penalty
- **#358** Auto-compound flag per stake (`PATCH /staking/:id/auto-compound`); rewards reinvested to principal each hour

Migration: `1745500000000-StakingFeatures` adds `staking_tiers`, `stake_delegations` tables and new columns on `stakes`.