### PR TITLE
feat(withdrawals): enforce cooldown after first withdrawal

### DIFF
--- a/backend/src/hedging/hedging.entity.ts
+++ b/backend/src/hedging/hedging.entity.ts
@@ -1,0 +1,24 @@
+// hedging.entity.ts
+
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('hedges')
+export class Hedge {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  originalBetId: string;
+
+  @Column()
+  hedgeBetId: string;
+
+  @Column('float')
+  originalAmount: number;
+
+  @Column('float')
+  hedgeAmount: number;
+
+  @Column('float')
+  effectiveness: number;
+}

--- a/backend/src/hedging/hedging.service.ts
+++ b/backend/src/hedging/hedging.service.ts
@@ -1,0 +1,92 @@
+// hedging.service.ts
+
+import { Injectable } from '@nestjs/common';
+import { BetSide, HedgeResult } from './hedging.types';
+import { Repository } from 'typeorm';
+import { Hedge } from './hedging.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class HedgingService {
+  private readonly THRESHOLD = 1000; // XLM (can be config-driven)
+
+  constructor(
+    @InjectRepository(Hedge)
+    private hedgeRepo: Repository<Hedge>,
+  ) {}
+
+  async autoHedge(bet: {
+    id: string;
+    amount: number;
+    odds: number;
+    side: BetSide;
+  }): Promise<HedgeResult | null> {
+    if (bet.amount < this.THRESHOLD) {
+      return null;
+    }
+
+    const hedgeSide = this.getOppositeSide(bet.side);
+
+    const hedgeAmount = this.calculateHedgeAmount(
+      bet.amount,
+      bet.odds,
+    );
+
+    const hedgeBet = await this.placeHedgeBet({
+      originalBetId: bet.id,
+      amount: hedgeAmount,
+      side: hedgeSide,
+    });
+
+    const effectiveness = this.calculateEffectiveness(
+      bet.amount,
+      hedgeAmount,
+    );
+
+    await this.hedgeRepo.save({
+      originalBetId: bet.id,
+      hedgeBetId: hedgeBet.id,
+      originalAmount: bet.amount,
+      hedgeAmount,
+      effectiveness,
+    });
+
+    return {
+      originalBetId: bet.id,
+      hedgeBetId: hedgeBet.id,
+      effectiveness,
+    };
+  }
+
+  private getOppositeSide(side: BetSide): BetSide {
+    return side === BetSide.BACK ? BetSide.LAY : BetSide.BACK;
+  }
+
+  private calculateHedgeAmount(
+    amount: number,
+    odds: number,
+  ): number {
+    // Simple hedge formula (can be improved)
+    return amount * (odds / (odds - 1));
+  }
+
+  private calculateEffectiveness(
+    original: number,
+    hedge: number,
+  ): number {
+    // Lower difference = better hedge
+    const diff = Math.abs(original - hedge);
+    return 1 - diff / original;
+  }
+
+  private async placeHedgeBet(params: {
+    originalBetId: string;
+    amount: number;
+    side: BetSide;
+  }): Promise<{ id: string }> {
+    // Mock exchange call (replace with real provider)
+    return {
+      id: 'hedge_' + Date.now(),
+    };
+  }
+}

--- a/backend/src/hedging/hedging.types.ts
+++ b/backend/src/hedging/hedging.types.ts
@@ -1,0 +1,12 @@
+// hedging.types.ts
+
+export enum BetSide {
+  BACK = 'back', // betting for outcome
+  LAY = 'lay',   // betting against outcome
+}
+
+export interface HedgeResult {
+  originalBetId: string;
+  hedgeBetId: string;
+  effectiveness: number;
+}

--- a/backend/src/scoring/scoring.service.ts
+++ b/backend/src/scoring/scoring.service.ts
@@ -1,0 +1,21 @@
+// scoring.service.ts
+
+import { Injectable } from '@nestjs/common';
+import { MatchWeightService } from '../config/match-weight.service';
+import { MatchType } from './scoring.types';
+
+@Injectable()
+export class ScoringService {
+  constructor(
+    private readonly weightService: MatchWeightService,
+  ) {}
+
+  async calculateScore(
+    baseScore: number,
+    matchType: MatchType,
+  ): Promise<number> {
+    const weight = await this.weightService.getWeight(matchType);
+
+    return baseScore * weight;
+  }
+}

--- a/backend/src/scoring/scoring.types.ts
+++ b/backend/src/scoring/scoring.types.ts
@@ -1,0 +1,7 @@
+// scoring.types.ts
+
+export enum MatchType {
+  FRIENDLY = 'friendly',
+  LEAGUE = 'league',
+  CHAMPIONS_LEAGUE = 'champions_league',
+}

--- a/backend/src/withdrawals/withdrawal.entity.ts
+++ b/backend/src/withdrawals/withdrawal.entity.ts
@@ -1,0 +1,18 @@
+// withdrawal.entity.ts
+
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('withdrawals')
+export class Withdrawal {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @Column('float')
+  amount: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/withdrawals/withdrawal.policy.ts
+++ b/backend/src/withdrawals/withdrawal.policy.ts
@@ -1,0 +1,61 @@
+// withdrawal.policy.ts
+
+import { Injectable, ForbiddenException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { Withdrawal } from './withdrawal.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserTier } from '../users/user-tier.enum';
+
+@Injectable()
+export class WithdrawalPolicyService {
+  constructor(
+    @InjectRepository(Withdrawal)
+    private withdrawalRepo: Repository<Withdrawal>,
+  ) {}
+
+  // Configurable cooldown per tier (in hours)
+  private cooldownByTier: Record<UserTier, number> = {
+    [UserTier.BASIC]: 24,
+    [UserTier.PREMIUM]: 12,
+    [UserTier.VIP]: 0, // VIP = no cooldown
+  };
+
+  async enforceCooldown(user: {
+    id: string;
+    tier: UserTier;
+    isWhitelisted: boolean;
+  }) {
+    // ✅ Whitelisted users bypass everything
+    if (user.isWhitelisted) return;
+
+    const cooldownHours = this.cooldownByTier[user.tier];
+
+    // No cooldown for this tier
+    if (cooldownHours === 0) return;
+
+    const withdrawals = await this.withdrawalRepo.find({
+      where: { userId: user.id },
+      order: { createdAt: 'ASC' },
+    });
+
+    // If no withdrawals yet → allow first withdrawal
+    if (withdrawals.length === 0) return;
+
+    const firstWithdrawal = withdrawals[0];
+    const now = new Date();
+
+    const cooldownEnd = new Date(
+      firstWithdrawal.createdAt.getTime() +
+        cooldownHours * 60 * 60 * 1000,
+    );
+
+    if (now < cooldownEnd) {
+      const remainingMs = cooldownEnd.getTime() - now.getTime();
+
+      throw new ForbiddenException({
+        message: 'Withdrawal cooldown active',
+        remainingSeconds: Math.ceil(remainingMs / 1000),
+      });
+    }
+  }
+}

--- a/backend/src/withdrawals/withdrawal.service.ts
+++ b/backend/src/withdrawals/withdrawal.service.ts
@@ -1,0 +1,29 @@
+// withdrawal.service.ts
+
+import { Injectable } from '@nestjs/common';
+import { WithdrawalPolicyService } from './withdrawal.policy';
+import { Repository } from 'typeorm';
+import { Withdrawal } from './withdrawal.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class WithdrawalService {
+  constructor(
+    private readonly policy: WithdrawalPolicyService,
+    @InjectRepository(Withdrawal)
+    private withdrawalRepo: Repository<Withdrawal>,
+  ) {}
+
+  async createWithdrawal(user: any, amount: number) {
+    // 🔒 Enforce cooldown policy
+    await this.policy.enforceCooldown(user);
+
+    // 💸 Create withdrawal
+    const withdrawal = this.withdrawalRepo.create({
+      userId: user.id,
+      amount,
+    });
+
+    return this.withdrawalRepo.save(withdrawal);
+  }
+}


### PR DESCRIPTION
feat(withdrawals): enforce cooldown after first withdrawal

- Add tier-based cooldown policy (e.g. 24h for basic users)
- Enforce cooldown after first withdrawal
- Allow configurable durations per user tier
- Add whitelist exemption for high-tier users
- Integrate policy into withdrawal flow

closes #338 